### PR TITLE
Symbols / Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+### sml-typed-abts
+
+This is a full implementation of Abstract Binding Trees from [Robert
+Harper](https://www.cs.cmu.edu/~rwh/)'s book, [Practical Foundations for
+Programming Languages](https://www.cs.cmu.edu/~rwh/plbook/2nded.pdf).
+
+In particular, this differs from many implementations of ABTs in the following
+respects:
+
+- Unlike Nuprl-style ABTs, this is a library for *many-sorted* abstract binding
+  trees.
+
+- We include a proper treatment of symbols and parameters in addition to
+  variables. Recall that whilst variables support substitution, symbols support
+  only fresh renaming. Operators are fibred over finite sets of symbols and sort
+  assignments, and sort-preserving injective maps of symbols lift to renamings of
+  operators' parameters. Valences account for the binding of both variables and
+  symbols. *Symbols are necessary in order to correctly implement assignables and
+  exceptions.*
+
+- Finally, the structure of terms has been generalized to support encodings
+  other than lists for bindings & spines; in general, the ABT framework may be
+  instantiated at any inductive fan.

--- a/example/example.sml
+++ b/example/example.sml
@@ -1,6 +1,8 @@
 structure Example =
 struct
   structure V = Symbol ()
+  structure I = Symbol ()
+
   structure O =
   struct
     structure Sort =
@@ -25,15 +27,15 @@ struct
     structure Arity = Arity (structure Sort = Sort and Spine = ListSpine)
 
     datatype operator = LAM of int | AP of int | NUM | LIT of int | RET
-    type t = operator
+    type 'i t = operator
 
-    structure Eq =
+    functor Eq (I : EQ) =
     struct
       type t = operator
       fun eq (x:t, y) = x = y
     end
 
-    structure Show =
+    functor Show (I : SHOW) =
     struct
       type t = operator
       fun toString (LAM i) = "lam"
@@ -57,10 +59,18 @@ struct
         | arity (AP i) = replicate (i + 1) (c EXP) ->> EXP
         | arity NUM = [c NAT] ->> VAL
         | arity (LIT _) = c NAT
+
+      fun proj theta = ([], arity theta)
+    end
+
+    structure Renaming =
+    struct
+      type 'i t = 'i t
+      fun map f theta = theta
     end
   end
 
-  structure Abt = AbtUtil(Abt (structure Operator = O and Variable = V))
+  structure Abt = AbtUtil(Abt (structure Operator = O and Variable = V and Symbol = I))
   structure ShowAbt = DebugShowAbt (Abt)
   open O O.Sort Abt
 

--- a/example/example.sml
+++ b/example/example.sml
@@ -107,7 +107,6 @@ struct
 
   val u = I.named "u"
 
-
   fun mkValence p q s = ({symbols = p, variables = q}, s)
   val n1 = RET $$ [NUM $$ [LIT 1 $$ []]]
   val expr1 =

--- a/example/example.sml
+++ b/example/example.sml
@@ -60,7 +60,7 @@ struct
     local
       open Sort
       fun replicate i x = List.tabulate (i, fn _ => x)
-      fun mkValence p q s = ({symbols = p, variables = q}, s)
+      fun mkValence p q s = ((p, q), s)
     in
       fun arity LAM = ([mkValence [] [EXP] EXP], EXP)
         | arity RET = ([mkValence [] [] VAL], EXP)
@@ -107,12 +107,11 @@ struct
 
   val u = I.named "u"
 
-  fun mkValence p q s = ({symbols = p, variables = q}, s)
   val n1 = RET $$ [NUM $$ [LIT 1 $$ []]]
   val expr1 =
     checkStar
       (DECL $$ [``a, ([u], []) \\ GET u $$ []],
-       mkValence [] [] EXP)
+       (([], []), EXP))
 
   val _ = print ("\n\n" ^ ShowAbt.toString expr1 ^ "\n\n")
 end

--- a/example/example.sml
+++ b/example/example.sml
@@ -26,23 +26,35 @@ struct
 
     structure Arity = Arity (structure Sort = Sort and Spine = ListSpine)
 
-    datatype operator = LAM | AP | NUM | LIT of int | RET
-    type 'i t = operator
+    datatype 'i t =
+        LAM | AP | NUM | LIT of int | RET
+      | DECL | GET of 'i | SET of 'i
 
     functor Eq (I : EQ) =
     struct
-      type t = operator
-      fun eq (x:t, y) = x = y
+      type t = I.t t
+      fun eq (LAM, LAM) = true
+        | eq (AP, AP) = true
+        | eq (NUM, NUM) = true
+        | eq (LIT m, LIT n) = m = n
+        | eq (RET, RET) = true
+        | eq (DECL, DECL) = true
+        | eq (GET i, GET j) = I.eq (i, j)
+        | eq (SET i, SET j) = I.eq (i, j)
+        | eq _ = false
     end
 
     functor Show (I : SHOW) =
     struct
-      type t = operator
+      type t = I.t t
       fun toString LAM = "lam"
         | toString AP = "ap"
         | toString NUM = "#"
         | toString (LIT n) = Int.toString n
         | toString RET = "ret"
+        | toString DECL = "∇"
+        | toString (GET i) = "get[" ^ I.toString i ^ "]"
+        | toString (SET i) = "set[" ^ I.toString i ^ "]"
     end
 
     local
@@ -55,6 +67,9 @@ struct
         | arity AP = ([mkValence [] [] EXP, mkValence [] [] EXP], EXP)
         | arity NUM = ([mkValence [] [] NAT], VAL)
         | arity (LIT _) = ([], NAT)
+        | arity DECL = ([mkValence [] [] EXP, mkValence [EXP] [] EXP], EXP)
+        | arity (GET _) = ([], EXP)
+        | arity (SET _) = ([mkValence [] [] EXP], EXP)
 
       fun proj theta = ([], arity theta)
     end
@@ -62,12 +77,19 @@ struct
     structure Renaming =
     struct
       type 'i t = 'i t
-      fun map f theta = theta
+      fun map f LAM = LAM
+        | map f AP = AP
+        | map f NUM = NUM
+        | map f (LIT n) = LIT n
+        | map f RET = RET
+        | map f DECL = DECL
+        | map f (GET i) = GET (f i)
+        | map f (SET i) = SET (f i)
     end
   end
 
   structure Abt = AbtUtil(Abt (structure Operator = O and Variable = V and Symbol = I))
-  structure ShowAbt = DebugShowAbt (Abt)
+  structure ShowAbt = PlainShowAbt (Abt)
   open O O.Sort Abt
 
   infixr 5 \
@@ -83,4 +105,15 @@ struct
   val a = V.named "a"
   val b = V.named "b"
 
+  val u = I.named "u"
+
+
+  fun mkValence p q s = ({symbols = p, variables = q}, s)
+  val n1 = RET $$ [NUM $$ [LIT 1 $$ []]]
+  val expr1 =
+    checkStar
+      (DECL $$ [``a, ([u], []) \\ GET u $$ []],
+       mkValence [] [] EXP)
+
+  val _ = print ("\n\n" ^ ShowAbt.toString expr1 ^ "\n\n")
 end

--- a/example/example.sml
+++ b/example/example.sml
@@ -74,7 +74,7 @@ struct
       fun proj theta = ([], arity theta)
     end
 
-    structure Renaming =
+    structure Presheaf =
     struct
       type 'i t = 'i t
       fun map f LAM = LAM

--- a/example/example.sml
+++ b/example/example.sml
@@ -26,7 +26,7 @@ struct
 
     structure Arity = Arity (structure Sort = Sort and Spine = ListSpine)
 
-    datatype operator = LAM of int | AP of int | NUM | LIT of int | RET
+    datatype operator = LAM | AP | NUM | LIT of int | RET
     type 'i t = operator
 
     functor Eq (I : EQ) =
@@ -38,27 +38,23 @@ struct
     functor Show (I : SHOW) =
     struct
       type t = operator
-      fun toString (LAM i) = "lam"
-        | toString (AP i) = "ap"
+      fun toString LAM = "lam"
+        | toString AP = "ap"
         | toString NUM = "#"
         | toString (LIT n) = Int.toString n
         | toString RET = "ret"
     end
 
-    fun ->> (rho, tau) = (rho, tau)
-    infixr ->>
-
-    fun c x = [] ->> x
-
     local
       open Sort
       fun replicate i x = List.tabulate (i, fn _ => x)
+      fun mkValence p q s = ({symbols = p, variables = q}, s)
     in
-      fun arity (LAM i) = [replicate i EXP ->> EXP] ->> VAL
-        | arity RET = [c VAL] ->> EXP
-        | arity (AP i) = replicate (i + 1) (c EXP) ->> EXP
-        | arity NUM = [c NAT] ->> VAL
-        | arity (LIT _) = c NAT
+      fun arity LAM = ([mkValence [] [EXP] EXP], EXP)
+        | arity RET = ([mkValence [] [] VAL], EXP)
+        | arity AP = ([mkValence [] [] EXP, mkValence [] [] EXP], EXP)
+        | arity NUM = ([mkValence [] [] NAT], VAL)
+        | arity (LIT _) = ([], NAT)
 
       fun proj theta = ([], arity theta)
     end
@@ -77,48 +73,6 @@ struct
   infixr 5 \
   infix 5 $
 
-  structure Eval =
-  struct
-    fun eval e =
-      let
-        val ((_, sigma), pat) = infer e
-      in
-        case pat of
-             `x => raise Fail "free variable"
-           | _ \ _ => raise Fail "unexpected binding"
-           | LAM i $ _ => e
-           | RET $ _ => e
-           | AP i $ es =>
-               let
-                 fun go (m :: []) = eval m
-                   | go (m :: es) =
-                     let
-                       val ((_, tau), RET $ [m']) = infer (eval m)
-                       val (_, LAM i $ [xsE]) = infer m'
-                       val (_, xs \ E) = infer xsE
-                       val i' = Int.min (i, List.length es)
-                       val es1 = List.take (es, i')
-                       val es2 = List.drop (es, i')
-                       val j = List.length es2
-                       val E' =
-                         ListPair.foldr
-                           (fn (x,e,mem) => subst (e,x) mem)
-                           E
-                           (xs, es1)
-                     in
-                       if j > 0 then
-                         go (E'::es2)
-                       else
-                         eval E'
-                     end
-                   | go _ = raise Match
-               in
-                 go es
-               end
-           | _ => raise Match
-      end
-  end
-
   val $$ = STAR o op$
   infix 5 $$
 
@@ -129,19 +83,4 @@ struct
   val a = V.named "a"
   val b = V.named "b"
 
-  fun lam xs e = LAM (List.length xs) $$ [xs \\ e]
-  fun ap es = AP (List.length es - 1) $$ es
-  fun ret x = RET $$ [x]
-  fun num x = NUM $$ [x]
-  fun lit n = LIT n $$ []
-
-  (* Two different implementations of const; one with multiabstraction, and
-   * another with iterated abstraction. *)
-  val const = lam [a,b] (``a)
-  val const' = lam [a] (ret (lam [b] (``a)))
-
-  val expr1 = checkStar (ap [ret const, ret (num (lit 1)), ret (num (lit 23))], c EXP)
-  val expr2 = checkStar (ap [ret const', ret (num (lit 1)), ret (num (lit 23))], c EXP)
-
-  val _ = print (ShowAbt.toString (Eval.eval expr1) ^ " == " ^ ShowAbt.toString (Eval.eval expr2) ^ "\n")
 end

--- a/example/example.sml
+++ b/example/example.sml
@@ -62,16 +62,14 @@ struct
       fun replicate i x = List.tabulate (i, fn _ => x)
       fun mkValence p q s = ((p, q), s)
     in
-      fun arity LAM = ([mkValence [] [EXP] EXP], EXP)
-        | arity RET = ([mkValence [] [] VAL], EXP)
-        | arity AP = ([mkValence [] [] EXP, mkValence [] [] EXP], EXP)
-        | arity NUM = ([mkValence [] [] NAT], VAL)
-        | arity (LIT _) = ([], NAT)
-        | arity DECL = ([mkValence [] [] EXP, mkValence [EXP] [] EXP], EXP)
-        | arity (GET _) = ([], EXP)
-        | arity (SET _) = ([mkValence [] [] EXP], EXP)
-
-      fun proj theta = ([], arity theta)
+      fun proj LAM = ([], ([mkValence [] [EXP] EXP], EXP))
+        | proj RET = ([], ([mkValence [] [] VAL], EXP))
+        | proj AP = ([], ([mkValence [] [] EXP, mkValence [] [] EXP], EXP))
+        | proj NUM = ([], ([mkValence [] [] NAT], VAL))
+        | proj (LIT _) = ([], ([], NAT))
+        | proj DECL = ([], ([mkValence [] [] EXP, mkValence [EXP] [] EXP], EXP))
+        | proj (GET i) = ([(i, EXP)], ([], EXP))
+        | proj (SET i) = ([(i, EXP)], ([mkValence [] [] EXP], EXP))
     end
 
     structure Presheaf =
@@ -103,11 +101,8 @@ struct
 
   val `` = STAR o `
   val a = V.named "a"
-  val b = V.named "b"
-
   val u = I.named "u"
 
-  val n1 = RET $$ [NUM $$ [LIT 1 $$ []]]
   val expr1 =
     checkStar
       (DECL $$ [``a, ([u], []) \\ GET u $$ []],

--- a/src/abt.fun
+++ b/src/abt.fun
@@ -36,6 +36,7 @@ struct
     type variable = variable t
 
     exception UnexpectedBoundName of coord
+
     fun getFree (FREE v) = v
       | getFree (BOUND i) = raise UnexpectedBoundName i
   end
@@ -147,8 +148,7 @@ struct
              APP (theta', Spine.Pair.mapEq chkInf (es, valences))
            end
 
-  and infer (V (LN.FREE v, sigma)) = ((Spine.empty (), sigma), ` v)
-    | infer (V _) = raise Fail "Impossible: unexpected bound variable"
+  and infer (V (v, sigma)) = ((Spine.empty (), sigma), ` (LN.getFree v))
     | infer (ABS (bindings, e)) =
       let
         val xs = Spine.Functor.map (Variable.clone o #1) bindings

--- a/src/abt.fun
+++ b/src/abt.fun
@@ -46,6 +46,14 @@ struct
       fun map f (FREE v) = FREE (f v)
         | map f (BOUND i) = BOUND i
     end
+
+    structure Monad : MONAD =
+    struct
+      type 'a t = 'a t
+      fun pure v = FREE v
+      fun bind f (FREE v) = f v
+        | bind f (BOUND i) = BOUND i
+    end
   end
 
   datatype abt =
@@ -154,9 +162,8 @@ struct
        | ABS (us, xs, e') => ABS (us, xs, imprisonSymbol v (Coord.shiftRight coord, e'))
        | APP (theta, es) =>
          let
-           fun rho (LN.FREE v') = if Symbol.Eq.eq (v, v') then LN.BOUND coord else LN.FREE v'
-             | rho v' = v'
-           val theta' = Operator.Presheaf.map rho theta
+           fun rho v' = if Symbol.Eq.eq (v, v') then LN.BOUND coord else LN.FREE v'
+           val theta' = Operator.Presheaf.map (LN.Monad.bind rho) theta
          in
            APP (theta', Spine.Functor.map (fn e => imprisonSymbol v (coord, e)) es)
          end

--- a/src/abt.fun
+++ b/src/abt.fun
@@ -155,7 +155,7 @@ struct
       ("expected " ^ Valence.Show.toString v1 ^ " == " ^ Valence.Show.toString v2)
       (Valence.Eq.eq (v1, v2))
 
-  fun check (e, valence as ({symbols,variables}, sigma)) =
+  fun check (e, valence as ((symbols,variables), sigma)) =
     case e of
          `x =>
            let
@@ -191,7 +191,7 @@ struct
 
   and infer (V (v, sigma)) =
       let
-        val valence = ({symbols = Spine.empty (), variables = Spine.empty ()}, sigma)
+        val valence = ((Spine.empty (), Spine.empty ()), sigma)
       in
         (valence, ` (LN.getFree v))
       end
@@ -199,13 +199,10 @@ struct
       let
         val us = Spine.Functor.map (Symbol.clone o #1) Ypsilon
         val xs = Spine.Functor.map (Variable.clone o #1) Gamma
-        val ({symbols, variables}, tau) = inferValence e
+        val ((symbols, variables), tau) = inferValence e
         val () = assert "variables not empty" (Spine.isEmpty variables)
         val () = assert "symbols not empty" (Spine.isEmpty symbols)
-        val valence =
-          ({symbols = Spine.Functor.map #2 Ypsilon,
-            variables = Spine.Functor.map #2 Gamma},
-           tau)
+        val valence = ((Spine.Functor.map #2 Ypsilon, Spine.Functor.map #2 Gamma), tau)
       in
         (valence, (us, xs) \ liberateVariables xs e)
       end
@@ -213,25 +210,25 @@ struct
       let
         val (_, (_, tau)) = Operator.proj theta
         val theta' = Operator.Renaming.map LN.getFree theta
-        val valence = ({symbols = Spine.empty (), variables = Spine.empty ()}, tau)
+        val valence = ((Spine.empty (), Spine.empty ()), tau)
       in
         (valence, theta' $ es)
       end
 
-  and inferValence (V (_, sigma)) = ({symbols = Spine.empty (), variables = Spine.empty ()}, sigma)
+  and inferValence (V (_, sigma)) = ((Spine.empty (), Spine.empty ()), sigma)
     | inferValence (ABS (Ypsilon, Gamma, e)) =
       let
         val (_, sigma) = inferValence e
         val symbolSorts = Spine.Functor.map #2 Ypsilon
         val variableSorts = Spine.Functor.map #2 Gamma
       in
-        ({symbols = symbolSorts, variables = variableSorts}, sigma)
+        ((symbolSorts, variableSorts), sigma)
       end
     | inferValence (APP (theta, es)) =
       let
         val (_, (_, sigma)) = Operator.proj theta
       in
-        ({symbols = Spine.empty (), variables = Spine.empty ()}, sigma)
+        ((Spine.empty (), Spine.empty ()), sigma)
       end
 
   structure Eq : EQ =

--- a/src/abt.sig
+++ b/src/abt.sig
@@ -1,10 +1,12 @@
 signature ABT =
 sig
+  structure Symbol : SYMBOL
   structure Variable : SYMBOL
   structure Operator : OPERATOR
 
+  type symbol = Symbol.t
   type variable = Variable.t
-  type operator = Operator.t
+  type operator = symbol Operator.t
   type sort = Operator.Arity.Sort.t
   type valence = Operator.Arity.Valence.t
   type 'a spine = 'a Operator.Arity.Valence.Spine.t

--- a/src/abt.sig
+++ b/src/abt.sig
@@ -14,6 +14,9 @@ sig
   type abt
   structure Eq : EQ where type t = abt
 
+  val freeVariables : abt -> variable list
+  val freeSymbols : abt -> symbol list
+
   (* Patterns for abstract binding trees. *)
   datatype 'a view =
       ` of variable

--- a/src/abt.sig
+++ b/src/abt.sig
@@ -18,7 +18,7 @@ sig
   datatype 'a view =
       ` of variable
     | $ of operator * 'a spine
-    | \ of variable spine * 'a
+    | \ of (symbol spine * variable spine) * 'a
 
   structure ViewFunctor : FUNCTOR where type 'a t = 'a view
 

--- a/src/abt.sig
+++ b/src/abt.sig
@@ -17,6 +17,13 @@ sig
   val freeVariables : abt -> variable list
   val freeSymbols : abt -> symbol list
 
+  (* subst (N, x) M ==== [N/x]M *)
+  val subst : abt * variable -> abt -> abt
+
+  (* rename (v, u) M === {v/u}M *)
+  val rename : symbol * symbol -> abt -> abt
+
+
   (* Patterns for abstract binding trees. *)
   datatype 'a view =
       ` of variable

--- a/src/abt_util.fun
+++ b/src/abt_util.fun
@@ -11,17 +11,6 @@ struct
   structure Valence = Arity.Valence
   structure Spine = Valence.Spine
 
-  fun subst (rho as (e, x)) e' =
-    case infer e' of
-         (_, ` y) => if Variable.Eq.eq (x, y) then e else e'
-       | (valence, (us, xs) \ e'') =>
-           if Spine.exists (fn y => Variable.Eq.eq (x, y)) xs then
-             e'
-           else
-             check ((us, xs) \ subst rho e'', valence)
-       | (valence, theta $ es) =>
-           check (theta $ Spine.Functor.map (subst rho) es, valence)
-
   fun checkStar (e, valence as ((symbols, variables), tau)) =
     case e of
          STAR (`x) => check (`x, valence)

--- a/src/abt_util.fun
+++ b/src/abt_util.fun
@@ -14,22 +14,22 @@ struct
   fun subst (rho as (e, x)) e' =
     case infer e' of
          (_, ` y) => if Variable.Eq.eq (x, y) then e else e'
-       | (valence, xs \ e'') =>
+       | (valence, (us, xs) \ e'') =>
            if Spine.exists (fn y => Variable.Eq.eq (x, y)) xs then
              e'
            else
-             check (xs \ subst rho e'', valence)
+             check ((us, xs) \ subst rho e'', valence)
        | (valence, theta $ es) =>
            check (theta $ Spine.Functor.map (subst rho) es, valence)
 
   fun checkStar (e, valence as ({symbols, variables}, tau)) =
     case e of
          STAR (`x) => check (`x, valence)
-       | STAR (xs \ e) =>
+       | STAR ((us, xs) \ e) =>
            let
              val e = checkStar (e, ({symbols = Spine.empty (), variables = Spine.empty ()}, tau))
            in
-             check (xs \ e, valence)
+             check ((us, xs) \ e, valence)
            end
        | STAR (theta $ es) =>
            let

--- a/src/abt_util.fun
+++ b/src/abt_util.fun
@@ -33,7 +33,7 @@ struct
            end
        | STAR (theta $ es) =>
            let
-             val (valences, _) = Operator.arity theta
+             val (_, (valences, _)) = Operator.proj theta
              val es = Spine.Pair.mapEq checkStar (es, valences)
            in
              check (theta $ es, valence)

--- a/src/abt_util.fun
+++ b/src/abt_util.fun
@@ -22,12 +22,12 @@ struct
        | (valence, theta $ es) =>
            check (theta $ Spine.Functor.map (subst rho) es, valence)
 
-  fun checkStar (e, valence as ({symbols, variables}, tau)) =
+  fun checkStar (e, valence as ((symbols, variables), tau)) =
     case e of
          STAR (`x) => check (`x, valence)
        | STAR ((us, xs) \ e) =>
            let
-             val e = checkStar (e, ({symbols = Spine.empty (), variables = Spine.empty ()}, tau))
+             val e = checkStar (e, ((Spine.empty (), Spine.empty ()), tau))
            in
              check ((us, xs) \ e, valence)
            end

--- a/src/abt_util.fun
+++ b/src/abt_util.fun
@@ -22,12 +22,12 @@ struct
        | (valence, theta $ es) =>
            check (theta $ Spine.Functor.map (subst rho) es, valence)
 
-  fun checkStar (e, valence as (sorts, tau)) =
+  fun checkStar (e, valence as ({symbols, variables}, tau)) =
     case e of
          STAR (`x) => check (`x, valence)
        | STAR (xs \ e) =>
            let
-             val e = checkStar (e, (Spine.empty (), tau))
+             val e = checkStar (e, ({symbols = Spine.empty (), variables = Spine.empty ()}, tau))
            in
              check (xs \ e, valence)
            end

--- a/src/abt_util.sig
+++ b/src/abt_util.sig
@@ -2,8 +2,6 @@ signature ABT_UTIL =
 sig
   include ABT
 
-  val subst : abt * variable -> abt -> abt
-
   (* abt patterns of variable depth *)
   datatype star = STAR of star view | EMB of abt
   val checkStar : star * valence -> abt

--- a/src/operator.sig
+++ b/src/operator.sig
@@ -10,6 +10,6 @@ sig
 
   val proj : 'i t -> ('i * Arity.Valence.sort) list * Arity.t
 
-  structure Renaming : FUNCTOR where type 'i t = 'i t
+  structure Presheaf : FUNCTOR where type 'i t = 'i t
 end
 

--- a/src/operator.sig
+++ b/src/operator.sig
@@ -1,12 +1,15 @@
-(* An arity-indexed family of operators *)
 signature OPERATOR =
 sig
   structure Arity : ARITY
 
-  type t
+  type 'i t
 
-  structure Eq : EQ where type t = t
-  structure Show : SHOW where type t = t
+  (* not Definition-compliant, but included in Successor ML *)
+  functor Eq (I : EQ) : EQ where type t = I.t t
+  functor Show (I : SHOW) : SHOW where type t = I.t t
 
-  val arity : t -> Arity.t
+  val proj : 'i t -> ('i * Arity.Valence.sort) list * Arity.t
+
+  structure Renaming : FUNCTOR where type 'i t = 'i t
 end
+

--- a/src/show_abt.fun
+++ b/src/show_abt.fun
@@ -8,6 +8,8 @@ struct
 
   structure Spine = Abt.Operator.Arity.Valence.Spine
 
+  structure OShow = Operator.Show (Abt.Symbol.Show)
+
   fun toString e =
     case #2 (infer e) of
          `x => ShowVar.toString x
@@ -16,9 +18,9 @@ struct
               ^ "." ^ toString e
        | theta $ es =>
            if Spine.isEmpty es then
-             Operator.Show.toString theta
+             OShow.toString theta
            else
-             Operator.Show.toString theta
+             OShow.toString theta
                 ^ "(" ^ Spine.pretty toString "; " es ^ ")"
 end
 

--- a/src/show_abt.fun
+++ b/src/show_abt.fun
@@ -1,7 +1,7 @@
 functor ShowAbt
   (structure Abt : ABT
-   structure ShowVar : SHOW
-     where type t = Abt.variable) :> SHOW where type t = Abt.abt =
+   structure ShowVar : SHOW where type t = Abt.variable
+   structure ShowSym : SHOW where type t = Abt.symbol) :> SHOW where type t = Abt.abt =
 struct
   open Abt infix $ infixr \
   type t = abt
@@ -13,9 +13,13 @@ struct
   fun toString e =
     case #2 (infer e) of
          `x => ShowVar.toString x
-       | xs \ e =>
-          Spine.pretty ShowVar.toString "," xs
-              ^ "." ^ toString e
+       | (us, xs) \ e =>
+           let
+             val us' = Spine.pretty ShowSym.toString "," us
+             val xs' = Spine.pretty ShowVar.toString "," xs
+           in
+             "{" ^ us' ^ "}[" ^ xs' ^ "]." ^ toString e
+           end
        | theta $ es =>
            if Spine.isEmpty es then
              OShow.toString theta
@@ -25,9 +29,9 @@ struct
 end
 
 functor PlainShowAbt (Abt : ABT) =
-  ShowAbt (structure Abt = Abt and ShowVar = Abt.Variable.Show)
+  ShowAbt (structure Abt = Abt and ShowVar = Abt.Variable.Show and ShowSym = Abt.Symbol.Show)
 
 functor DebugShowAbt (Abt : ABT) =
-  ShowAbt (structure Abt = Abt and ShowVar = Abt.Variable.DebugShow)
+  ShowAbt (structure Abt = Abt and ShowVar = Abt.Variable.DebugShow and ShowSym = Abt.Symbol.DebugShow)
 
 

--- a/src/valence.fun
+++ b/src/valence.fun
@@ -2,27 +2,25 @@ functor Valence (structure Sort : SORT and Spine : SPINE) : VALENCE =
 struct
   type sort = Sort.t
   structure Spine = Spine
-  type bindings =
-    {symbols : sort Spine.t,
-     variables : sort Spine.t}
+  type bindings = sort Spine.t * sort Spine.t
   type t = bindings * sort
 
   structure Eq =
   struct
     type t = t
-    fun eq ((bindings : bindings, sigma), (bindings' : bindings, sigma')) =
-      Spine.Pair.allEq Sort.Eq.eq (#symbols bindings, #symbols bindings')
-        andalso Spine.Pair.allEq Sort.Eq.eq (#variables bindings, #variables bindings')
+    fun eq (((symbolSorts, variableSorts), sigma), ((symbolSorts', variableSorts'), sigma')) =
+      Spine.Pair.allEq Sort.Eq.eq (symbolSorts, symbolSorts')
+        andalso Spine.Pair.allEq Sort.Eq.eq (variableSorts, variableSorts')
         andalso Sort.Eq.eq (sigma, sigma')
   end
 
   structure Show =
   struct
     type t = t
-    fun toString ({symbols,variables}, sigma) =
+    fun toString ((symbolSorts,variableSorts), sigma) =
       let
-        val symbols' = Spine.pretty Sort.Show.toString ", " symbols
-        val variables' = Spine.pretty Sort.Show.toString ", " variables
+        val symbols' = Spine.pretty Sort.Show.toString ", " symbolSorts
+        val variables' = Spine.pretty Sort.Show.toString ", " variableSorts
         val sigma' = Sort.Show.toString sigma
       in
         "{" ^ symbols' ^ "}(" ^ variables' ^ ")" ^ sigma'

--- a/src/valence.fun
+++ b/src/valence.fun
@@ -2,25 +2,30 @@ functor Valence (structure Sort : SORT and Spine : SPINE) : VALENCE =
 struct
   type sort = Sort.t
   structure Spine = Spine
-  type t = sort Spine.t * sort
+  type bindings =
+    {symbols : sort Spine.t,
+     variables : sort Spine.t}
+  type t = bindings * sort
 
   structure Eq =
   struct
     type t = t
-    fun eq ((sorts, sigma), (sorts', sigma')) =
-      Spine.Pair.allEq Sort.Eq.eq (sorts, sorts')
+    fun eq ((bindings : bindings, sigma), (bindings' : bindings, sigma')) =
+      Spine.Pair.allEq Sort.Eq.eq (#symbols bindings, #symbols bindings')
+        andalso Spine.Pair.allEq Sort.Eq.eq (#variables bindings, #variables bindings')
         andalso Sort.Eq.eq (sigma, sigma')
   end
 
   structure Show =
   struct
     type t = t
-    fun toString (sorts, sigma) =
+    fun toString ({symbols,variables}, sigma) =
       let
-        val sorts' = Spine.pretty Sort.Show.toString ", " sorts
+        val symbols' = Spine.pretty Sort.Show.toString ", " symbols
+        val variables' = Spine.pretty Sort.Show.toString ", " variables
         val sigma' = Sort.Show.toString sigma
       in
-        "(" ^ sorts' ^ ")" ^ sigma'
+        "{" ^ symbols' ^ "}(" ^ variables' ^ ")" ^ sigma'
       end
   end
 end

--- a/src/valence.sig
+++ b/src/valence.sig
@@ -2,7 +2,12 @@ signature VALENCE =
 sig
   type sort
   structure Spine : SPINE
-  type t = sort Spine.t * sort
+
+  type bindings =
+    {symbols : sort Spine.t,
+     variables : sort Spine.t}
+
+  type t = bindings * sort
 
   structure Show : SHOW where type t = t
   structure Eq : EQ where type t = t

--- a/src/valence.sig
+++ b/src/valence.sig
@@ -3,10 +3,8 @@ sig
   type sort
   structure Spine : SPINE
 
-  type bindings =
-    {symbols : sort Spine.t,
-     variables : sort Spine.t}
-
+  (* bindings are lists of symbol sorts and variable sorts respectively *)
+  type bindings = sort Spine.t * sort Spine.t
   type t = bindings * sort
 
   structure Show : SHOW where type t = t


### PR DESCRIPTION
#1

The general approach I've taken is to have the operator type be polymorphic in the type of symbols it takes, and then implement renaming as a functor. In this sense, I'm taking the presheaf thing that I had in the paper wholesale.

The nice thing about this approach (that is, not being concrete in the type of symbols at the level of operators) is that it is now possible to use a locally nameless representation for operators' parameters as well, which I didn't think would be possible before! Basically, internally the `abt` instantiates the operator at `symbol + debruijn`.
