### PR TITLE
Add ASTs, and conversion from ASTs to ABTs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/cmlib"]
+	path = lib/cmlib
+	url = https://github.com/standardml/cmlib.git

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ At the `-` prompt, type:
 
 You should see a lot of compilation messages and then:
 
-    decl({}[].m{}[]; {u}[].get[u])
+    decl(#m; {u}.get[u])

--- a/abt.cm
+++ b/abt.cm
@@ -3,6 +3,7 @@ Library
   signature ABT_UTIL
   signature AST
   signature OPERATOR
+  signature PRESYMBOL
   signature SYMBOL
   signature VALENCE
   signature SORT
@@ -11,6 +12,7 @@ Library
   signature METACONTEXT
 
   functor Symbol
+  structure StringPresymbol
   structure ListSpine
   functor Arity
   functor Metacontext

--- a/abt.cm
+++ b/abt.cm
@@ -1,6 +1,7 @@
 Library
   signature ABT
   signature ABT_UTIL
+  signature AST
   signature OPERATOR
   signature SYMBOL
   signature VALENCE
@@ -15,13 +16,17 @@ Library
   functor Metacontext
   functor Abt
   functor AbtUtil
+  functor Ast
   functor ShowAbt
   functor PlainShowAbt
   functor DebugShowAbt
+
+  signature AST_TO_ABT
+  functor AstToAbt
 is
   $/basis.cm
-
   basis/basis.cm
+  lib/cmlib.cm
 
   src/symbol.sig
   src/symbol.fun
@@ -35,6 +40,7 @@ is
   src/spine.sml
   src/arity.sig
   src/operator.sig
+  src/ast.sig
   src/abt.sig
   src/abt_util.sig
   src/abt_util.fun
@@ -42,6 +48,7 @@ is
   src/valence.fun
   src/arity.fun
   src/abt.fun
+  src/ast.fun
 
   src/coord.sig
   src/coord.sml

--- a/abt.mlb
+++ b/abt.mlb
@@ -2,6 +2,7 @@ local
   $(SML_LIB)/basis/basis.mlb
 
   basis/basis.mlb
+  lib/cmlib.mlb
 
   src/coord.sig
   src/coord.sml
@@ -19,17 +20,21 @@ local
   src/arity.sig
   src/operator.sig
   src/abt.sig
+  src/ast.sig
   src/abt_util.sig
   src/abt_util.fun
   src/show_abt.fun
   src/valence.fun
   src/arity.fun
   src/abt.fun
+  src/ast.fun
 
 in
   signature OPERATOR
   signature ABT
   signature ABT_UTIL
+  signature AST
+  signature AST_TO_ABT
   signature SYMBOL
   signature SORT
   signature SPINE
@@ -46,4 +51,6 @@ in
   functor ShowAbt
   functor PlainShowAbt
   functor DebugShowAbt
+  functor Ast
+  functor AstToAbt
 end

--- a/abt.mlb
+++ b/abt.mlb
@@ -35,6 +35,8 @@ in
   signature ABT_UTIL
   signature AST
   signature AST_TO_ABT
+  signature PRE_SYMBOL
+  signature PRESYMBOL
   signature SYMBOL
   signature SORT
   signature SPINE
@@ -43,6 +45,7 @@ in
   signature METACONTEXT
 
   functor Symbol
+  structure StringPresymbol
   structure ListSpine
   functor Arity
   functor Metacontext

--- a/lib/cmlib.cm
+++ b/lib/cmlib.cm
@@ -1,0 +1,5 @@
+Library
+  functor SplayDict
+  structure StringOrdered
+is
+  cmlib/cmlib.cm

--- a/lib/cmlib.mlb
+++ b/lib/cmlib.mlb
@@ -1,0 +1,6 @@
+local
+  cmlib/cmlib.mlb
+in
+  functor SplayDict
+  structure StringOrdered
+end

--- a/src/abt.fun
+++ b/src/abt.fun
@@ -14,7 +14,7 @@ end
 functor Abt
   (structure Symbol : SYMBOL
    structure Variable : SYMBOL
-   structure Metavariable : SYMBOL
+   structure Metavariable : PRESYMBOL
    structure Operator : OPERATOR
    structure Metacontext : METACONTEXT
      where type metavariable = Metavariable.t

--- a/src/abt.fun
+++ b/src/abt.fun
@@ -132,7 +132,7 @@ struct
           | go R (APP (theta, Es)) =
               Spine.Foldable.foldr MCtx.union R (Spine.Functor.map (go' MCtx.empty) Es)
           | go R (META_APP (mv, us, Ms)) =
-              Spine.Foldable.foldr MCtx.union (MCtx.updateMonotonic R mv) (Spine.Functor.map (go MCtx.empty) Ms)
+              Spine.Foldable.foldr MCtx.union (MCtx.extend R mv) (Spine.Functor.map (go MCtx.empty) Ms)
         and go' R (ABS (_, _, M)) = go R M
       in
         go MCtx.empty M

--- a/src/abt.sig
+++ b/src/abt.sig
@@ -36,12 +36,12 @@ sig
   val rename : symbol * symbol -> abt -> abt
 
   (* Patterns for abstract binding trees. *)
+  datatype 'a bview =
+     \ of (symbol spine * variable spine) * 'a
   datatype 'a view =
       ` of variable
     | $ of operator * 'a bview spine
     | $# of metavariable * (symbol spine * 'a spine)
-  and 'a bview =
-     \ of (symbol spine * variable spine) * 'a
 
   structure Functor : FUNCTOR
     where type 'a t = 'a view

--- a/src/abt.sig
+++ b/src/abt.sig
@@ -3,7 +3,7 @@ sig
   structure Symbol : SYMBOL
   structure Variable : SYMBOL
   structure Operator : OPERATOR
-  structure Metavariable : SYMBOL
+  structure Metavariable : PRESYMBOL
   structure Metacontext : METACONTEXT
     where type metavariable = Metavariable.t
     where type valence = Operator.Arity.Valence.t

--- a/src/abt_util.fun
+++ b/src/abt_util.fun
@@ -11,32 +11,32 @@ struct
   structure Valence = Arity.Valence
   structure Spine = Valence.Spine
 
-  fun checkStar Theta M tau =
-    case M of
-         STAR (`x) => check Theta (`x, tau)
-       | STAR (theta $ Es) =>
+  fun checkStar Th m tau =
+    case m of
+         STAR (`x) => check Th (`x, tau)
+       | STAR (theta $ es) =>
            let
-             val (valences, _) = Operator.arity theta
-             val Es' =
+             val (vls, _) = Operator.arity theta
+             val es' =
                Spine.Pair.mapEq
-                 (fn (E, valence as (_, sigma)) =>
-                     BFunctor.map (fn M => checkStar Theta M sigma) E)
-                 (Es, valences)
+                 (fn (e, vl as (_, sigma)) =>
+                     BFunctor.map (fn n => checkStar Th n sigma) e)
+                 (es, vls)
            in
-             check Theta (theta $ Es', tau)
+             check Th (theta $ es', tau)
            end
-       | STAR (mv $# (us, Ms)) =>
+       | STAR (mv $# (us, ms)) =>
            let
-             val ((_, vsorts), tau) = Abt.Metacontext.lookup Theta mv
-             val Ms' = Spine.Pair.mapEq (fn (M, sigma) => checkStar Theta M sigma) (Ms, vsorts)
+             val ((_, vsorts), tau) = Abt.Metacontext.lookup Th mv
+             val ms' = Spine.Pair.mapEq (fn (n, sigma) => checkStar Th n sigma) (ms, vsorts)
            in
-             check Theta (mv $# (us, Ms'), tau)
+             check Th (mv $# (us, ms'), tau)
            end
        | EMB M =>
            let
              val (M', _) = infer M
            in
-             check Theta (M', tau)
+             check Th (M', tau)
            end
 end
 

--- a/src/ast.fun
+++ b/src/ast.fun
@@ -1,0 +1,69 @@
+functor Ast (O : OPERATOR) : AST =
+struct
+  type symbol = string
+  type variable = string
+  type metavariable = string
+
+  type 'i operator = 'i O.t
+  type 'a spine = 'a O.Arity.Valence.Spine.t
+
+  datatype ast =
+      ` of variable
+    | $ of symbol operator * btm spine
+    | $# of metavariable * (symbol spine * ast spine)
+  and btm = \ of (symbol spine * variable spine) * ast
+end
+
+functor AstToAbt (X : AST_ABT) : AST_TO_ABT =
+struct
+  open X
+
+  structure Spine = Abt.Operator.Arity.Valence.Spine
+  structure Ctx = SplayDict (structure Key = StringOrdered)
+
+  type sctx = Abt.symbol Ctx.dict
+  type vctx = Abt.variable Ctx.dict
+
+  fun variable Vs x =
+    Ctx.lookup Vs x
+    handle _ =>
+      Abt.Variable.named x
+
+  fun symbol Ss u =
+    Ctx.lookup Ss u
+    handle _ =>
+      Abt.Symbol.named u
+
+  fun hconvert Th (Ss, Vs) (m, tau) =
+    case m of
+         Ast.` x => Abt.check Th (Abt.` (variable Vs x), tau)
+       | Ast.$ (theta, es) =>
+          let
+            val (vls, _) = Abt.Operator.arity theta
+            val theta' = Abt.Operator.Presheaf.map (symbol Ss) theta
+            val es' = Spine.Pair.mapEq (hconvertb Th (Ss, Vs)) (es, vls)
+          in
+            Abt.check Th (Abt.$ (theta', es'), tau)
+          end
+       | Ast.$# (mv, (us, ms)) =>
+           let
+             val ((_, vsorts), _) = Abt.Metacontext.lookup Th mv
+             val us' = Spine.Functor.map (symbol Ss) us
+             val ms' = Spine.Pair.mapEq (hconvert Th (Ss, Vs)) (ms, vsorts)
+           in
+             Abt.check Th (Abt.$# (mv, (us', ms')), tau)
+           end
+  and hconvertb Th (Ss, Vs) (Ast.\ ((us, xs), m), vl) : Abt.abt Abt.bview =
+    let
+      val ((ssorts, vsorts), tau) = vl
+      val us' = Spine.Functor.map Abt.Symbol.named us
+      val xs' = Spine.Functor.map Abt.Variable.named xs
+      val Ss' = Spine.Foldable.foldr (fn ((u, u'), Ss') => Ctx.insert Ss' u u') Ss (Spine.Pair.zipEq (us, us'))
+      val Vs' = Spine.Foldable.foldr (fn ((x, x'), Vs') => Ctx.insert Vs' x x') Vs (Spine.Pair.zipEq (xs, xs'))
+    in
+      Abt.\ ((us', xs'), hconvert Th (Ss', Vs') (m, tau))
+    end
+
+  fun convert Th m =
+    hconvert Th (Ctx.empty, Ctx.empty) m
+end

--- a/src/ast.sig
+++ b/src/ast.sig
@@ -1,0 +1,32 @@
+signature AST =
+sig
+  type 'i operator
+  type 'a spine
+
+  type symbol = string
+  type variable = string
+  type metavariable
+
+  datatype ast =
+      ` of variable
+    | $ of symbol operator * btm spine
+    | $# of metavariable * (symbol spine * ast spine)
+  and btm = \ of (symbol spine * variable spine) * ast
+end
+
+signature AST_ABT =
+sig
+  structure Abt : ABT
+  structure Ast : AST
+
+  sharing type Ast.operator = Abt.Operator.t
+  sharing type Ast.metavariable = Abt.Metavariable.t
+  sharing type Ast.spine = Abt.Operator.Arity.Valence.Spine.t
+end
+
+signature AST_TO_ABT =
+sig
+  include AST_ABT
+
+  val convert : Abt.metacontext -> Ast.ast * Abt.sort -> Abt.abt
+end

--- a/src/ast.sig
+++ b/src/ast.sig
@@ -28,5 +28,22 @@ signature AST_TO_ABT =
 sig
   include AST_ABT
 
-  val convert : Abt.metacontext -> Ast.ast * Abt.sort -> Abt.abt
+  structure NameEnv :
+  sig
+    type 'a t
+    val fromList : (string * 'a) list -> 'a t
+  end
+
+  (* convert a closed ast to an abt *)
+  val convert
+    : Abt.metacontext
+    -> Ast.ast * Abt.sort
+    -> Abt.abt
+
+  (* convert an open ast to an abt *)
+  val convertOpen
+    : Abt.metacontext
+    -> Abt.symbol NameEnv.t * Abt.variable NameEnv.t
+    -> Ast.ast * Abt.sort
+    -> Abt.abt
 end

--- a/src/context.fun
+++ b/src/context.fun
@@ -25,9 +25,17 @@ struct
     Ctx.insertMerge Th m v
       (fn v' => merge (v, v'))
 
+  fun extendUnique Th (m, v) =
+    Ctx.insertMerge Th m v
+      (fn _ => raise MergeFailure)
+
   fun union (Th, Th') =
     Ctx.union Th Th'
       (fn (_, v, v') => merge (v, v'))
+
+  fun concat (Th, Th') =
+    Ctx.union Th Th'
+      (fn _ => raise MergeFailure)
 
   fun lookup Th m =
     Ctx.lookup Th m

--- a/src/context.fun
+++ b/src/context.fun
@@ -1,5 +1,5 @@
 functor Metacontext
-  (structure Metavariable : SYMBOL
+  (structure Metavariable : PRESYMBOL
    structure Valence : EQ) :> METACONTEXT where type metavariable = Metavariable.t and type valence = Valence.t =
 struct
   type metavariable = Metavariable.t

--- a/src/context.sig
+++ b/src/context.sig
@@ -4,27 +4,16 @@ sig
   type metavariable
   type valence
 
-  val empty : t
-
   val isEmpty : t -> bool
   val toList : t -> (metavariable * valence) list
 
-  exception NameClash
-
-  (* raises NameClash *)
+  val empty : t
   val extend : t -> metavariable * valence -> t
-
-  (* raises NameClash *)
-  val concat : t * t -> t
-
-  (* raises NameClash if the name is already present with a different valence *)
-  val updateMonotonic : t -> metavariable * valence -> t
   val union : t * t -> t
 
-  exception MetavariableNotFound
-
-  (* raises MetavariableNotFound *)
   val lookup : t -> metavariable -> valence
-
   val find : t -> metavariable -> valence option
+
+  exception MetavariableNotFound
+  exception MergeFailure
 end

--- a/src/context.sig
+++ b/src/context.sig
@@ -8,8 +8,20 @@ sig
   val toList : t -> (metavariable * valence) list
 
   val empty : t
+
+  (* raises MergeFailure if the variable is already present with an incompatible
+   * valence *)
   val extend : t -> metavariable * valence -> t
+
+  (* raises MergeFailure if the variable is already present *)
+  val extendUnique : t -> metavariable * valence -> t
+
+  (* raises MergeFailure if variables are already present with incompatible
+   * valences *)
   val union : t * t -> t
+
+  (* raises MergeFailure if variables are already present *)
+  val concat: t * t -> t
 
   val lookup : t -> metavariable -> valence
   val find : t -> metavariable -> valence option

--- a/src/show_abt.fun
+++ b/src/show_abt.fun
@@ -1,6 +1,5 @@
 functor ShowAbt
   (structure Abt : ABT
-   structure ShowMetavar : SHOW where type t = Abt.metavariable
    structure ShowVar : SHOW where type t = Abt.variable
    structure ShowSym : SHOW where type t = Abt.symbol) :> SHOW where type t = Abt.abt =
 struct
@@ -24,7 +23,7 @@ struct
              val us' = Spine.pretty ShowSym.toString "," us
              val es' = Spine.pretty toString "," es
            in
-             "#" ^ ShowMetavar.toString mv
+             "#" ^ Abt.Metavariable.Show.toString mv
                  ^ (if Spine.isEmpty us then "" else "{" ^ us' ^ "}")
                  ^ (if Spine.isEmpty es then "" else "[" ^ es' ^ "]")
            end
@@ -48,14 +47,12 @@ end
 functor PlainShowAbt (Abt : ABT) =
   ShowAbt
     (structure Abt = Abt
-     and ShowMetavar = Abt.Metavariable.Show
      and ShowVar = Abt.Variable.Show
      and ShowSym = Abt.Symbol.Show)
 
 functor DebugShowAbt (Abt : ABT) =
   ShowAbt
     (structure Abt = Abt
-     and ShowMetavar = Abt.Metavariable.DebugShow
      and ShowVar = Abt.Variable.DebugShow
      and ShowSym = Abt.Symbol.DebugShow)
 

--- a/src/show_abt.fun
+++ b/src/show_abt.fun
@@ -8,7 +8,6 @@ struct
   type t = abt
 
   structure Spine = Abt.Operator.Arity.Valence.Spine
-
   structure SShow = Abt.Symbol.Show
 
   fun toString M =

--- a/src/show_abt.fun
+++ b/src/show_abt.fun
@@ -25,15 +25,22 @@ struct
              val us' = Spine.pretty ShowSym.toString "," us
              val es' = Spine.pretty toString "," es
            in
-             ShowMetavar.toString mv ^ "{" ^ us' ^ "}[" ^ es' ^ "]"
+             "#" ^ ShowMetavar.toString mv
+                 ^ (if Spine.isEmpty us then "" else "{" ^ us' ^ "}")
+                 ^ (if Spine.isEmpty es then "" else "[" ^ es' ^ "]")
            end
 
   and toStringB ((us, xs) \ M) =
     let
+      val symEmpty = Spine.isEmpty us
+      val varEmpty = Spine.isEmpty xs
       val us' = Spine.pretty ShowSym.toString "," us
       val xs' = Spine.pretty ShowVar.toString "," xs
     in
-      "{" ^ us' ^ "}[" ^ xs' ^ "]." ^ toString M
+      (if symEmpty then "" else "{" ^ us' ^ "}")
+        ^ (if varEmpty then "" else "[" ^ xs' ^ "]")
+        ^ (if symEmpty andalso varEmpty then "" else ".")
+        ^ toString M
     end
 
 

--- a/src/symbol.fun
+++ b/src/symbol.fun
@@ -2,6 +2,7 @@ functor Symbol () :> SYMBOL =
 struct
   type t = int * string
   val counter = ref 0
+
   fun named a =
     let
       val i = !counter
@@ -9,6 +10,9 @@ struct
     in
       (i, a)
     end
+
+  fun new () =
+    named "@"
 
   fun compare ((i, _), (j, _)) =
     Int.compare (i, j)
@@ -36,3 +40,22 @@ struct
   end
 end
 
+structure StringPresymbol : PRESYMBOL =
+struct
+  type t = string
+  fun named x = x
+
+  structure Show =
+  struct
+    type t = t
+    fun toString x = x
+  end
+
+  structure Eq =
+  struct
+    type t = t
+    fun eq (x, y) = x = y
+  end
+
+  val compare = String.compare
+end

--- a/src/symbol.sig
+++ b/src/symbol.sig
@@ -1,13 +1,20 @@
-signature SYMBOL =
+signature PRESYMBOL =
 sig
   type t
   val named : string -> t
 
   structure Show : SHOW where type t = t
-  structure DebugShow : SHOW where type t = t
   structure Eq : EQ where type t = t
 
   val compare : t * t -> order
+end
+
+signature SYMBOL =
+sig
+  include PRESYMBOL
+  val new : unit -> t
   val clone : t -> t
+
+  structure DebugShow : SHOW where type t = t
 end
 


### PR DESCRIPTION
Got this banged out while waiting for some stuff to happen at work; related to #10.
- ASTs are like ABTs, but have strings for variables & symbols
- parsers should be factored through the conversion from ASTs into ABTs

I've added cmlib as a _local_ dependency (i.e. we don't export any of its types, but we just use it to implement some stuff). Because it's entirely private, we don't need to use any path anchors or anything like that.

Still need to do:
- [x] update `.mlb` files

@jozefg 
