### PR TITLE
cubical abts?

### DIFF
--- a/abt.cm
+++ b/abt.cm
@@ -28,9 +28,7 @@ Library
   functor ContextUtil
   functor Abt
   functor SimpleAbt
-  (*
   functor Ast
-  *)
   functor ShowAbt
   functor PlainShowAbt
   functor DebugShowAbt

--- a/abt.cm
+++ b/abt.cm
@@ -36,10 +36,8 @@ Library
   functor AbtSyntaxView
   functor AstSyntaxView
 
-(*
   signature AST_TO_ABT
   functor AstToAbt
-  *)
 is
   $/basis.cm
   locally-nameless.cm

--- a/abt.cm
+++ b/abt.cm
@@ -34,6 +34,7 @@ Library
   functor PlainShowAbt
   functor DebugShowAbt
   functor AbtSimpleOperator
+  functor AbtSimpleCubicalOperator
   functor AbtEmptyOperator
 
   functor AbtSyntaxView

--- a/abt.cm
+++ b/abt.cm
@@ -1,6 +1,7 @@
 Library
   signature ABT
   signature AST
+  signature ABT_PARAM
   signature ABT_OPERATOR
   signature ABT_SIMPLE_OPERATOR
   signature ABT_SYMBOL
@@ -24,6 +25,8 @@ Library
   functor ListAbtArity
   structure UnisortedAbtArity
   functor ContextUtil
+  structure AbtIdParam
+  structure AbtCubicalParam
   functor Abt
   functor SimpleAbt
   functor Ast
@@ -53,6 +56,8 @@ is
   src/core/spine.sig
   src/core/spine.sml
   src/core/arity.sig
+  src/core/param.sig
+  src/core/param.sml
   src/core/operator.sig
   src/core/operator.fun
   src/core/ast.sig

--- a/abt.cm
+++ b/abt.cm
@@ -12,8 +12,10 @@ Library
   signature ABT_ARITY
   signature UNISORTED_ABT_ARITY
   signature CONTEXT_UTIL
+  (*
   signature ABT_SYNTAX_VIEW_INTO
   signature ABT_SYNTAX_VIEW
+  *)
 
   functor AbtSymbol
   structure StringAbtSymbol
@@ -26,18 +28,24 @@ Library
   functor ContextUtil
   functor Abt
   functor SimpleAbt
+  (*
   functor Ast
+  *)
   functor ShowAbt
   functor PlainShowAbt
   functor DebugShowAbt
   functor AbtSimpleOperator
   functor AbtEmptyOperator
 
+(*
   functor AbtSyntaxView
   functor AstSyntaxView
+  *)
 
+(*
   signature AST_TO_ABT
   functor AstToAbt
+  *)
 is
   $/basis.cm
   locally-nameless.cm
@@ -63,5 +71,7 @@ is
   src/core/abt.fun
   src/core/ast.fun
 
+(*
   src/core/syntax_view.sig
   src/core/syntax_view.fun
+  *)

--- a/abt.cm
+++ b/abt.cm
@@ -12,10 +12,8 @@ Library
   signature ABT_ARITY
   signature UNISORTED_ABT_ARITY
   signature CONTEXT_UTIL
-  (*
   signature ABT_SYNTAX_VIEW_INTO
   signature ABT_SYNTAX_VIEW
-  *)
 
   functor AbtSymbol
   structure StringAbtSymbol
@@ -35,10 +33,8 @@ Library
   functor AbtSimpleOperator
   functor AbtEmptyOperator
 
-(*
   functor AbtSyntaxView
   functor AstSyntaxView
-  *)
 
 (*
   signature AST_TO_ABT
@@ -69,7 +65,5 @@ is
   src/core/abt.fun
   src/core/ast.fun
 
-(*
   src/core/syntax_view.sig
   src/core/syntax_view.fun
-  *)

--- a/abt.mlb
+++ b/abt.mlb
@@ -66,6 +66,7 @@ in
   functor PlainShowAbt
   functor DebugShowAbt
   functor AbtSimpleOperator
+  functor AbtSimpleCubicalOperator
   functor AbtEmptyOperator
   functor Ast
   functor AstToAbt

--- a/abt.mlb
+++ b/abt.mlb
@@ -15,7 +15,7 @@ local
   src/core/spine.sml
   src/core/arity.sig
   src/core/param.sig
-  src/core/param.fun
+  src/core/param.sml
   src/core/operator.sig
   src/core/operator.fun
   src/core/abt.sig

--- a/abt.mlb
+++ b/abt.mlb
@@ -14,6 +14,8 @@ local
   src/core/valence.sig
   src/core/spine.sml
   src/core/arity.sig
+  src/core/param.sig
+  src/core/param.fun
   src/core/operator.sig
   src/core/operator.fun
   src/core/abt.sig
@@ -28,6 +30,7 @@ local
   src/core/syntax_view.fun
 
 in
+  signature ABT_PARAM
   signature ABT_OPERATOR
   signature ABT_SIMPLE_OPERATOR
   signature ABT
@@ -55,6 +58,8 @@ in
   functor ListAbtArity
   structure UnisortedAbtArity
   functor ContextUtil
+  structure AbtIdParam
+  structure AbtCubicalParam
   functor Abt
   functor SimpleAbt
   functor ShowAbt

--- a/example/example.sml
+++ b/example/example.sml
@@ -6,6 +6,8 @@ struct
 
   structure O =
   struct
+    structure P = AbtIdParam
+
     structure S =
     struct
       datatype t = EXP | VAL | NAT
@@ -108,6 +110,7 @@ struct
     val parseInt =
       repeat1 digit wth valOf o Int.fromString o String.implode
 
+    val parseParam = identifier 
     val parse : string O.t CharParser.charParser =
       string "lam" return LAM
         || string "ap" return AP

--- a/src/core/abt.fun
+++ b/src/core/abt.fun
@@ -437,12 +437,11 @@ struct
      *)
     fun eq (V (v, _), V (v', _)) = LN.eq Var.eq (v, v')
       | eq (APP (theta, es <: _), APP (theta', es' <: _)) =
-          OpLnEq.eq (theta, theta')
-          (*andalso Sp.Pair.allEq eqAbs (es, es')*)
-      (*| eq (META_APP ((mv, _), us, ms <: _), META_APP ((mv', _), us', ms' <: _)) =
+          OpLnEq.eq (theta, theta') andalso Sp.Pair.allEq eqAbs (es, es')
+      | eq (META_APP ((mv, _), ps, ms <: _), META_APP ((mv', _), ps', ms' <: _)) =
           Metavar.eq (mv, mv')
-            andalso Sp.Pair.allEq (fn ((x, _), (y, _)) => LN.eq Sym.eq (x,y)) (us, us')
-            andalso Sp.Pair.allEq eq (ms, ms')*)
+            andalso Sp.Pair.allEq (fn ((p, _), (q, _)) => P.eq (LN.eq Sym.eq) (p,q)) (ps, ps')
+            andalso Sp.Pair.allEq eq (ms, ms')
       | eq _ = false
     and eqAbs (ABS (_, _, m), ABS (_, _, m')) = eq (m, m')
   end

--- a/src/core/abt.fun
+++ b/src/core/abt.fun
@@ -2,11 +2,18 @@ functor Abt
   (structure Sym : ABT_SYMBOL
    structure Var : ABT_SYMBOL
    structure Metavar : ABT_SYMBOL
-   structure O : ABT_OPERATOR) : ABT =
+   structure O : ABT_OPERATOR
+   structure P : PARAM) : ABT =
 struct
   structure Sym = Sym and Var = Var and Metavar = Metavar and O = O and Ar = O.Ar
   structure S = Ar.Vl.S and Valence = Ar.Vl
   structure Sp = Valence.Sp
+
+  structure P =
+  struct
+    structure F = FunctorOfMonad (P)
+    open P F
+  end
 
   structure MetaCtx = Metavar.Ctx
   structure VarCtx = Var.Ctx
@@ -18,14 +25,16 @@ struct
   type symbol = Sym.t
   type variable = Var.t
   type metavariable = Metavar.t
-  type operator = symbol O.t
   type 'a spine = 'a Sp.t
+  type 'a param = 'a P.t
+  type operator = symbol param O.t
 
   structure LN =
   struct
     local structure S = LocallyNameless (LnCoord) in open S end
     type symbol = symbol t
-    type operator = symbol O.t
+    type param = symbol param
+    type operator = param O.t
     type variable = variable t
   end
 
@@ -77,13 +86,13 @@ struct
   datatype abt =
       V of LN.variable * sort
     | APP of LN.operator * abs spine ann
-    | META_APP of (metavariable * sort) * (LN.symbol * sort) spine * abt spine ann
+    | META_APP of (metavariable * sort) * (LN.param * sort) spine * abt spine ann
   and abs = ABS of (string * sort) spine * (string * sort) spine * abt
 
   val rec primToString =
     fn V (v, _) => LN.toString Var.toString v
      | APP (theta, es <: _) =>
-         O.toString (LN.toString Sym.toString) theta
+         O.toString (P.toString (LN.toString Sym.toString)) theta
            ^ "("
            ^ Sp.pretty primToStringAbs ";" es
            ^ ")"
@@ -96,7 +105,7 @@ struct
 
   type metaenv = abs MetaCtx.dict
   type varenv = abt VarCtx.dict
-  type symenv = symbol SymCtx.dict
+  type symenv = symbol param SymCtx.dict
 
   fun abtToAbs m =
     ABS (Sp.empty (), Sp.empty (), m)
@@ -105,7 +114,7 @@ struct
   datatype 'a view =
       ` of variable
     | $ of operator * 'a bview spine
-    | $# of metavariable * ((symbol * sort) spine * 'a spine)
+    | $# of metavariable * ((symbol param * sort) spine * 'a spine)
   and 'a bview =
      \ of (symbol spine * variable spine) * 'a
 
@@ -150,9 +159,9 @@ struct
   val metactx =
     fn V _ => MetaCtx.empty
      | APP (theta, es <: (mctx, _, _)) => Susp.force mctx
-     | META_APP ((mv, tau), us, ms <: (mctx, _, _)) =>
+     | META_APP ((mv, tau), ps, ms <: (mctx, _, _)) =>
          let
-           val vl = ((Sp.map #2 us, Sp.map sort ms), tau)
+           val vl = ((Sp.map #2 ps, Sp.map sort ms), tau)
          in
            Ctx.MetaCtxUtil.extend (Susp.force mctx) (mv, vl)
          end
@@ -161,16 +170,20 @@ struct
     fn V _ => SymCtx.empty
      | APP (theta, es <: (_, sctx, _)) =>
          List.foldr
-           (fn ((LN.FREE u, tau), memo) => Ctx.SymCtxUtil.extend memo (u, tau)
-             | (_, memo) => memo)
+           (fn ((p, tau), memo) =>
+              (case P.extract p of
+                  SOME (LN.FREE u) => Ctx.SymCtxUtil.extend memo (u, tau)
+                | _ => memo))
            (Susp.force sctx)
            (O.support theta)
-     | META_APP (_, us, ms <: (_, sctx, _)) =>
+     | META_APP (_, ps, ms <: (_, sctx, _)) =>
          Sp.foldr
-           (fn ((LN.FREE u, tau), memo) => Ctx.SymCtxUtil.extend memo (u, tau)
-             | (_, memo) => memo)
+           (fn ((p, tau), memo) =>
+              (case P.extract p of
+                  SOME (LN.FREE u) => Ctx.SymCtxUtil.extend memo (u, tau)
+                | _ => memo))
            (Susp.force sctx)
-           us
+           ps
 
   val varctx =
     fn V (LN.FREE x, sigma) => VarCtx.singleton x sigma
@@ -229,19 +242,21 @@ struct
      | APP (theta, es <: ctx) =>
          let
            fun rho v' = if Sym.eq (v, v') then LN.BOUND coord else LN.FREE v'
-           fun chk (LN.FREE v', tau') = if Sym.eq (v, v') then assertSortEq (tau, tau') else ()
-             | chk _ = ()
+           fun chk (p', tau') =
+             case P.extract p' of
+                SOME (LN.FREE v') => if Sym.eq (v, v') then assertSortEq (tau, tau') else ()
+              | _ => ()
            val _ = List.app chk (O.support theta)
-           val theta' = O.map (LN.bind rho) theta
+           val theta' = O.map (P.map (LN.bind rho)) theta
            val ctx' = Ctx.modifySyms (fn sctx => SymCtx.remove sctx v) ctx
          in
            APP (theta', Sp.map (liftTraverseAbs (imprisonSymbol (v,tau)) coord) es <: ctx')
          end
-     | META_APP (m, us, Ms <: ctx) =>
+     | META_APP (m, ps, Ms <: ctx) =>
          let
            fun rho v' = if Sym.eq (v, v') then LN.BOUND coord else LN.FREE v'
-           fun rho' (l, s) = (LN.bind rho l, s)
-           val vs = Sp.map rho' us
+           fun rho' (l, s) = (P.map (LN.bind rho) l, s)
+           val vs = Sp.map rho' ps
            val ctx' = Ctx.modifySyms (fn sctx => SymCtx.remove sctx v) ctx
          in
            META_APP (m, vs, Sp.map (imprisonSymbol (v, tau) coord) Ms <: ctx')
@@ -256,8 +271,8 @@ struct
          if LnCoord.eq (coord, coord') then V (LN.FREE v, sigma) else e
      | APP (theta, es <: ctx) =>
          annotateApp theta (Sp.map (liftTraverseAbs (liberateVariable (v, sigma)) coord) es)
-     | META_APP ((x, tau), us, ms <: ctx) =>
-         annotateMetaApp (x, tau) us (Sp.map (liberateVariable (v, sigma) coord) ms)
+     | META_APP ((x, tau), ps, ms <: ctx) =>
+         annotateMetaApp (x, tau) ps (Sp.map (liberateVariable (v, sigma) coord) ms)
 
   fun liberateSymbol (u, sigma) coord =
     let
@@ -267,18 +282,18 @@ struct
       fn e as V _ => e
        | APP (theta, es <: ctx) =>
            let
-             val theta' = O.map rho theta
+             val theta' = O.map (P.map rho) theta
              val fs = Sp.map (liftTraverseAbs (liberateSymbol (u, sigma)) coord) es
            in
              annotateApp theta' fs
            end
-       | META_APP ((x, tau), us, ms <: ctx) =>
+       | META_APP ((x, tau), ps, ms <: ctx) =>
            let
-             val vs = Sp.map (fn (l,s) => (rho l, s)) us
+             val qs = Sp.map (fn (l,s) => (P.map rho l, s)) ps
              val ns = Sp.map (liberateSymbol (u, sigma) coord) ms
              val ctx' = Ctx.modifySyms (fn sctx => SymCtx.insert sctx u sigma) ctx
            in
-             annotateMetaApp (x, tau) vs ns
+             annotateMetaApp (x, tau) qs ns
            end
     end
 
@@ -317,15 +332,15 @@ struct
   end
 
 
-  fun checkb ((us, xs) \ m, ((ssorts, vsorts), sigma)) =
+  fun checkb ((us, xs) \ m, ((psorts, vsorts), sigma)) =
     let
       val (_, tau) = infer m
       val () = assertSortEq (sigma, tau)
     in
       ABS
-        (Sp.Pair.zipEq (Sp.map Sym.toString us, ssorts),
+        (Sp.Pair.zipEq (Sp.map Sym.toString us, psorts),
          Sp.Pair.zipEq (Sp.map Var.toString xs, vsorts),
-         imprisonSymbols (us, ssorts) (imprisonVariables (xs, vsorts) m))
+         imprisonSymbols (us, psorts) (imprisonVariables (xs, vsorts) m))
     end
 
   and infer M =
@@ -334,16 +349,16 @@ struct
        | APP (theta, Es <: _) =>
          let
            val (_, tau) = O.arity theta
-           val theta' = O.map LN.getFree theta
+           val theta' = O.map (P.map LN.getFree) theta
            val Es' = Sp.map (#1 o inferb) Es
          in
            (theta' $ Es', tau)
          end
-       | META_APP ((mv, tau), us, Ms <: _) =>
+       | META_APP ((mv, tau), ps, Ms <: _) =>
          let
-           val us' = Sp.map (fn (u, sigma) => (LN.getFree u, sigma)) us
+           val ps' = Sp.map (fn (p, sigma) => (P.map (LN.getFree) p, sigma)) ps
          in
-           (mv $# (us', Ms), tau)
+           (mv $# (ps', Ms), tau)
          end
 
   and inferb (ABS (upsilon, gamma, m)) =
@@ -372,23 +387,22 @@ struct
            let
              val (valences, tau)  = O.arity theta
              val () = assertSortEq (sigma, tau)
-             val theta' = O.map LN.FREE theta
+             val theta' = O.map (P.map LN.FREE) theta
              val es' = Sp.Pair.mapEq checkb (es, valences)
            in
              annotateApp theta' es'
            end
-       | x $# (us, ms) =>
+       | x $# (ps, ms) =>
            let
-             val ssorts = Sp.map #2 us
+             val psorts = Sp.map #2 ps
              val vsorts = Sp.map sort ms
 
-             val us' = Sp.map (fn (u, tau) => (LN.FREE u, tau)) us
-             fun chkInf (m, tau) =
-               (assertSortEq (tau, sort m); m)
+             val ps' = Sp.map (fn (p, tau) => (P.map LN.FREE p, tau)) ps
+             fun chkInf (m, tau) = (assertSortEq (tau, sort m); m)
              val ms' = Sp.Pair.mapEq chkInf (ms, vsorts)
              val ctx = Sp.foldr (fn (m, ctx) => Ctx.merge (ctx, getCtx m)) Ctx.empty ms'
            in
-             annotateMetaApp (x, sigma) us' ms'
+             annotateMetaApp (x, sigma) ps' ms'
            end
 
   fun $$ (theta, es) =
@@ -416,18 +430,19 @@ struct
          mv $# (us, Sp.map f ms)
 
   local
-    structure OpLnEq = struct val eq = O.eq (LN.eq Sym.eq) end
+    structure OpLnEq = struct val eq = O.eq (P.eq (LN.eq Sym.eq)) end
   in
     (* While this looks simple by using locally nameless representations this
      * implements alpha equivalence (and is very efficient!)
      *)
     fun eq (V (v, _), V (v', _)) = LN.eq Var.eq (v, v')
       | eq (APP (theta, es <: _), APP (theta', es' <: _)) =
-          OpLnEq.eq (theta, theta') andalso Sp.Pair.allEq eqAbs (es, es')
-      | eq (META_APP ((mv, _), us, ms <: _), META_APP ((mv', _), us', ms' <: _)) =
+          OpLnEq.eq (theta, theta')
+          (*andalso Sp.Pair.allEq eqAbs (es, es')*)
+      (*| eq (META_APP ((mv, _), us, ms <: _), META_APP ((mv', _), us', ms' <: _)) =
           Metavar.eq (mv, mv')
             andalso Sp.Pair.allEq (fn ((x, _), (y, _)) => LN.eq Sym.eq (x,y)) (us, us')
-            andalso Sp.Pair.allEq eq (ms, ms')
+            andalso Sp.Pair.allEq eq (ms, ms')*)
       | eq _ = false
     and eqAbs (ABS (_, _, m), ABS (_, _, m')) = eq (m, m')
   end
@@ -440,21 +455,21 @@ struct
            `x => m
          | theta $ es =>
              check (theta $ Sp.map (mapb (metasubstEnv rho)) es, tau)
-         | mv $# (us, ms) =>
+         | mv $# (ps, ms) =>
              let
                val ms' = Sp.map (metasubstEnv rho) ms
              in
                case MetaCtx.find rho mv of
                     NONE =>
-                      check (mv $# (us, ms'), tau)
+                      check (mv $# (ps, ms'), tau)
                   | SOME abs =>
                       let
                         val (vs, xs) \ m = outb abs
                         val srho =
                           Sp.foldr
-                            (fn ((v, (u, _)), r) => SymCtx.insert r v u)
+                            (fn ((v, (p, _)), r) => SymCtx.insert r v p)
                             SymCtx.empty
-                            (Sp.Pair.zipEq (vs, us))
+                            (Sp.Pair.zipEq (vs, ps))
                         val rho' =
                           Sp.foldr
                             (fn ((x,m), rho) => VarCtx.insert rho x m)
@@ -476,15 +491,17 @@ struct
     fn m as V _ => m
      | APP (theta, es <: _) =>
          let
-           fun ren u = getOpt (SymCtx.find rho u, u)
-           val theta' = O.map (LN.map ren) theta
+           fun ren (LN.FREE u) = P.map LN.FREE (getOpt (SymCtx.find rho u, P.pure u))
+             | ren l = P.pure l
+           val theta' = O.map (P.bind ren) theta
          in
            annotateApp theta' (Sp.map (mapAbs_ (renameEnv rho)) es)
          end
      | META_APP (mv, us, ms <: _) =>
          let
-           fun ren u = getOpt (SymCtx.find rho u, u)
-           fun ren' (l,s) = (LN.map ren l, s)
+           fun ren (LN.FREE u) = P.map LN.FREE (getOpt (SymCtx.find rho u, P.pure u))
+             | ren l = P.pure l
+           fun ren' (l,s) = (P.bind ren l, s)
          in
            annotateMetaApp mv (Sp.map ren' us) (Sp.map (renameEnv rho) ms)
          end
@@ -494,7 +511,7 @@ struct
       val (vs, xs) \ m = outb abs
       val srho =
         Sp.foldr
-          (fn ((v,u), rho) => SymCtx.insert rho v u)
+          (fn ((v,u), rho) => SymCtx.insert rho v (P.pure u))
           SymCtx.empty
           (Sp.Pair.zipEq (vs, us))
       val vrho =
@@ -512,7 +529,7 @@ struct
 
   fun subst (n, x) = substEnv (VarCtx.insert VarCtx.empty x n)
   fun metasubst (e, mv) = metasubstEnv (MetaCtx.insert MetaCtx.empty mv e)
-  fun rename (v, u) = renameEnv (SymCtx.insert SymCtx.empty u v)
+  fun rename (p, u) = renameEnv (SymCtx.insert SymCtx.empty u p)
 
   fun mapSubterms f m =
     let
@@ -534,17 +551,21 @@ struct
     structure SymRenUtil = ContextUtil (structure Ctx = SymCtx and Elem = Sym)
     structure VarRenUtil = ContextUtil (structure Ctx = VarCtx and Elem = Var)
 
-    fun unifySymbols ((u, sigma), (v, tau), rho) =
+    fun unifyParams ((p, sigma), (q, tau), rho) =
       if S.eq (sigma, tau) then
-        case (u, v) of
-            (LN.FREE u', LN.FREE v') =>
+        case (P.extract p, P.extract q) of
+           (SOME (LN.FREE u'), SOME (LN.FREE v')) =>
               SymRenUtil.extend rho (u', v')
-          | (LN.BOUND i, LN.BOUND j) =>
+         | (SOME (LN.BOUND i), SOME (LN.BOUND j)) =>
               if LnCoord.eq (i, j) then
                 rho
               else
                 raise UnificationFailed
-          | _ => raise UnificationFailed
+         | _ =>
+              if P.eq (LN.eq Sym.eq) (p, q) then
+                rho
+              else
+                 raise UnificationFailed
       else
         raise UnificationFailed
 
@@ -554,7 +575,7 @@ struct
           val us = O.support theta1
           val vs = O.support theta2
         in
-          ListPair.foldlEq unifySymbols rho (us, vs)
+          ListPair.foldlEq unifyParams rho (us, vs)
         end
       else
         raise UnificationFailed
@@ -580,16 +601,16 @@ struct
                  (mrho, srho', vrho)
                  (Sp.Pair.zipEq (es1, es2))
              end
-         | (META_APP ((x1, tau1), us1, ms1 <: _), META_APP ((x2, tau2), us2, ms2 <: _)) =>
+         | (META_APP ((x1, tau1), ps1, ms1 <: _), META_APP ((x2, tau2), ps2, ms2 <: _)) =>
              let
                val _ = if S.eq (tau1, tau2) then () else raise UnificationFailed
                val mrho' =
                  MetaRenUtil.extend mrho (x1, x2)
                val srho' =
                  Sp.foldr
-                   (fn ((u, v), rho) => unifySymbols (u, v, rho))
+                   (fn ((p, q), rho) => unifyParams (p, q, rho))
                    srho
-                   (Sp.Pair.zipEq (us1, us2))
+                   (Sp.Pair.zipEq (ps1, ps2))
              in
                Sp.foldr
                  (fn ((m1, m2), acc) => go acc (m1, m2))
@@ -613,8 +634,57 @@ struct
 
 end
 
+structure IdMonad =
+struct
+  type 'i t = 'i
+  fun pure x = x
+  fun bind f x = f x
+
+  fun extract x = SOME x
+  fun eq f = f
+  fun toString f = f
+end
+
+structure CubeMonad =
+struct
+  datatype 'i t =
+     NAME of 'i
+   | DIM0
+   | DIM1
+
+  val pure = NAME
+
+  fun bind f =
+    fn NAME u => f u
+     | DIM0 => DIM0
+     | DIM1 => DIM1
+
+  val extract =
+    fn NAME u => SOME u
+     | _ => NONE
+
+  fun eq f =
+    fn (NAME u, NAME v) => f (u, v)
+     | (DIM0, DIM0) => true
+     | (DIM1, DIM1) => true
+     | _ => false
+
+  fun toString f =
+    fn NAME u => f u
+     | DIM0 => "dim0"
+     | DIM1 => "dim1"
+end
+
 functor SimpleAbt (O : ABT_OPERATOR) =
   Abt (structure Sym = AbtSymbol ()
        structure Var = AbtSymbol ()
        structure Metavar = AbtSymbol ()
-       structure O = O)
+       structure O = O
+       structure P = IdMonad)
+
+functor CubicalAbt (O : ABT_OPERATOR) =
+  Abt (structure Sym = AbtSymbol ()
+       structure Var = AbtSymbol ()
+       structure Metavar = AbtSymbol ()
+       structure O = O
+       structure P = CubeMonad)

--- a/src/core/abt.fun
+++ b/src/core/abt.fun
@@ -3,7 +3,7 @@ functor Abt
    structure Var : ABT_SYMBOL
    structure Metavar : ABT_SYMBOL
    structure O : ABT_OPERATOR
-   structure P : PARAM) : ABT =
+   structure P : ABT_PARAM) : ABT =
 struct
   structure Sym = Sym and Var = Var and Metavar = Metavar and O = O and Ar = O.Ar
   structure S = Ar.Vl.S and Valence = Ar.Vl

--- a/src/core/abt.sig
+++ b/src/core/abt.sig
@@ -2,7 +2,7 @@
  * signature describes every operation generally needed to manipulate syntax.
  *)
 
-signature PARAM =
+signature ABT_PARAM =
 sig
   include MONAD
 
@@ -32,7 +32,7 @@ sig
   structure O : ABT_OPERATOR
 
   (* Symbolic parameter monad *)
-  structure P : PARAM
+  structure P : ABT_PARAM
 
   (* Convienent shorthands for the types found in the above structures *)
   type symbol = Sym.t

--- a/src/core/abt.sig
+++ b/src/core/abt.sig
@@ -2,15 +2,6 @@
  * signature describes every operation generally needed to manipulate syntax.
  *)
 
-signature ABT_PARAM =
-sig
-  include MONAD
-
-  val extract : 'i t -> 'i option
-  val eq : ('i * 'i -> bool) -> 'i t * 'i t -> bool
-  val toString : ('i -> string) -> 'i t -> string
-end
-
 signature ABT =
 sig
   structure Var : ABT_SYMBOL
@@ -31,9 +22,6 @@ sig
    * often referred to as "function symbols". *)
   structure O : ABT_OPERATOR
 
-  (* Symbolic parameter monad *)
-  structure P : ABT_PARAM
-
   (* Convienent shorthands for the types found in the above structures *)
   type symbol = Sym.t
   type variable = Var.t
@@ -41,7 +29,7 @@ sig
   type sort = O.Ar.sort
   type valence = O.Ar.valence
   type 'a spine = 'a O.Ar.spine
-  type 'a param = 'a P.t
+  type 'a param = 'a O.P.t
 
   type operator = symbol param O.t
 

--- a/src/core/abt.sig
+++ b/src/core/abt.sig
@@ -2,6 +2,15 @@
  * signature describes every operation generally needed to manipulate syntax.
  *)
 
+signature PARAM =
+sig
+  include MONAD
+
+  val extract : 'i t -> 'i option
+  val eq : ('i * 'i -> bool) -> 'i t * 'i t -> bool
+  val toString : ('i -> string) -> 'i t -> string
+end
+
 signature ABT =
 sig
   structure Var : ABT_SYMBOL
@@ -22,14 +31,19 @@ sig
    * often referred to as "function symbols". *)
   structure O : ABT_OPERATOR
 
+  (* Symbolic parameter monad *)
+  structure P : PARAM
+
   (* Convienent shorthands for the types found in the above structures *)
   type symbol = Sym.t
   type variable = Var.t
   type metavariable = Metavar.t
-  type operator = symbol O.t
   type sort = O.Ar.sort
   type valence = O.Ar.valence
   type 'a spine = 'a O.Ar.spine
+  type 'a param = 'a P.t
+
+  type operator = symbol param O.t
 
   (* The core type of the signature. This is the type of the ABTs that
    * can be built from the given [operator]s, [variable]s, [symbol]s and
@@ -50,7 +64,7 @@ sig
 
   type metaenv = abs Metavar.ctx
   type varenv = abt Var.ctx
-  type symenv = symbol Sym.ctx
+  type symenv = symbol param Sym.ctx
 
   (* Modify the term inside an abstraction*)
   val mapAbs : (abt -> abt) -> abs -> abs
@@ -88,7 +102,7 @@ sig
   (* Below we provide unary versions of the simultaneous substitution operations *)
   val metasubst : abs * metavariable -> abt -> abt
   val subst : abt * variable -> abt -> abt
-  val rename : symbol * symbol -> abt -> abt
+  val rename : symbol param * symbol -> abt -> abt
 
   (* Patterns for abstract binding trees. *)
 
@@ -108,7 +122,7 @@ sig
   datatype 'a view =
       ` of variable
     | $ of operator * 'a bview spine
-    | $# of metavariable * ((symbol * sort) spine * 'a spine)
+    | $# of metavariable * ((symbol param * sort) spine * 'a spine)
 
   val map : ('a -> 'b) -> 'a view -> 'b view
   val mapb : ('a -> 'b) -> 'a bview -> 'b bview

--- a/src/core/ast.fun
+++ b/src/core/ast.fun
@@ -1,20 +1,22 @@
 functor Ast
   (structure Operator : ABT_OPERATOR
-   structure Metavar : ABT_SYMBOL) : AST =
+   structure Metavar : ABT_SYMBOL
+   structure P : ABT_PARAM) : AST =
 struct
   type symbol = string
   type variable = string
   type metavariable = Metavar.t
+  type param = symbol P.t
 
-  structure Sp = Operator.Ar.Vl.Sp
+  structure P = P and Sp = Operator.Ar.Vl.Sp
 
   type 'i operator = 'i Operator.t
   type 'a spine = 'a Sp.t
 
   datatype ast =
       ` of variable
-    | $ of symbol operator * abs spine
-    | $# of metavariable * (symbol spine * ast spine)
+    | $ of param operator * abs spine
+    | $# of metavariable * (param spine * ast spine)
   and abs = \ of (symbol spine * variable spine) * ast
 
   infix $ $# \
@@ -23,17 +25,17 @@ struct
     fn `x => x
      | theta $ es =>
          if Sp.isEmpty es then
-           Operator.toString (fn x => x) theta
+           Operator.toString (P.toString (fn x => x)) theta
          else
-           Operator.toString (fn x => x) theta
+           Operator.toString (P.toString (fn x => x)) theta
               ^ "(" ^ Sp.pretty toStringB "; " es ^ ")"
-     | mv $# (us, es) =>
+     | mv $# (ps, es) =>
          let
-           val us' = Sp.pretty (fn x => x) "," us
+           val ps' = Sp.pretty (P.toString (fn x => x)) "," ps
            val es' = Sp.pretty toString "," es
          in
            "#" ^ Metavar.toString mv
-               ^ (if Sp.isEmpty us then "" else "{" ^ us' ^ "}")
+               ^ (if Sp.isEmpty ps then "" else "{" ^ ps' ^ "}")
                ^ (if Sp.isEmpty es then "" else "[" ^ es' ^ "]")
          end
 
@@ -57,8 +59,12 @@ struct
   open X
 
   structure Sp = Abt.O.Ar.Vl.Sp
-
   structure NameEnv = SplayDict (structure Key = StringOrdered)
+  structure P =
+  struct
+    open Abt.P
+    local structure Functor = FunctorOfMonad (Abt.P) in open Functor end
+  end
 
   fun variable vnames x =
     NameEnv.lookup vnames x
@@ -76,23 +82,23 @@ struct
        | Ast.$ (theta, es) =>
           let
             val (vls, _) = Abt.O.arity theta
-            val theta' = Abt.O.map (symbol snames) theta
+            val theta' = Abt.O.map (P.map (symbol snames)) theta
             val es' = Sp.Pair.mapEq (convertOpenAbs psi (snames, vnames)) (es, vls)
           in
             Abt.check (Abt.$ (theta', es'), tau)
           end
-       | Ast.$# (mv, (us, ms)) =>
+       | Ast.$# (mv, (ps, ms)) =>
            let
-             val ((ssorts, vsorts), _) = Abt.Metavar.Ctx.lookup psi mv
-             val us' = Sp.Pair.zipEq (Sp.map (symbol snames) us, ssorts)
+             val ((psorts, vsorts), _) = Abt.Metavar.Ctx.lookup psi mv
+             val ps' = Sp.Pair.zipEq (Sp.map (P.map (symbol snames)) ps, psorts)
              val ms' = Sp.Pair.mapEq (convertOpen psi (snames, vnames)) (ms, vsorts)
            in
-             Abt.check (Abt.$# (mv, (us', ms')), tau)
+             Abt.check (Abt.$# (mv, (ps', ms')), tau)
            end
 
   and convertOpenAbs psi (snames, vnames) (Ast.\ ((us, xs), m), vl) : Abt.abt Abt.bview =
     let
-      val ((ssorts, vsorts), tau) = vl
+      val ((psorts, vsorts), tau) = vl
       val us' = Sp.map Abt.Sym.named us
       val xs' = Sp.map Abt.Var.named xs
       val snames' = Sp.foldr (fn ((u, u'), snames') => NameEnv.insert snames' u u') snames (Sp.Pair.zipEq (us, us'))

--- a/src/core/ast.fun
+++ b/src/core/ast.fun
@@ -1,14 +1,14 @@
 functor Ast
   (structure Operator : ABT_OPERATOR
-   structure Metavar : ABT_SYMBOL
-   structure P : ABT_PARAM) : AST =
+   structure Metavar : ABT_SYMBOL) : AST =
 struct
   type symbol = string
   type variable = string
   type metavariable = Metavar.t
-  type param = symbol P.t
+  type param = symbol Operator.P.t
 
-  structure P = P and Sp = Operator.Ar.Vl.Sp
+  structure O = Operator
+  structure P = O.P and Sp = Operator.Ar.Vl.Sp
 
   type 'i operator = 'i Operator.t
   type 'a spine = 'a Sp.t
@@ -25,13 +25,13 @@ struct
     fn `x => x
      | theta $ es =>
          if Sp.isEmpty es then
-           Operator.toString (P.toString (fn x => x)) theta
+           Operator.toString (O.P.toString (fn x => x)) theta
          else
-           Operator.toString (P.toString (fn x => x)) theta
+           Operator.toString (O.P.toString (fn x => x)) theta
               ^ "(" ^ Sp.pretty toStringB "; " es ^ ")"
      | mv $# (ps, es) =>
          let
-           val ps' = Sp.pretty (P.toString (fn x => x)) "," ps
+           val ps' = Sp.pretty (O.P.toString (fn x => x)) "," ps
            val es' = Sp.pretty toString "," es
          in
            "#" ^ Metavar.toString mv
@@ -62,8 +62,8 @@ struct
   structure NameEnv = SplayDict (structure Key = StringOrdered)
   structure P =
   struct
-    open Abt.P
-    local structure Functor = FunctorOfMonad (Abt.P) in open Functor end
+    open Abt.O.P
+    local structure Functor = FunctorOfMonad (Abt.O.P) in open Functor end
   end
 
   fun variable vnames x =

--- a/src/core/ast.sig
+++ b/src/core/ast.sig
@@ -3,14 +3,17 @@ sig
   type 'i operator
   type 'a spine
 
+  structure P : ABT_PARAM
+
   type symbol = string
   type variable = string
+  type param = symbol P.t
   type metavariable
 
   datatype ast =
       ` of variable
-    | $ of symbol operator * abs spine
-    | $# of metavariable * (symbol spine * ast spine)
+    | $ of param operator * abs spine
+    | $# of metavariable * (param spine * ast spine)
   and abs = \ of (symbol spine * variable spine) * ast
 
   val toString : ast -> string
@@ -24,6 +27,7 @@ sig
   sharing type Ast.operator = Abt.O.t
   sharing type Ast.metavariable = Abt.Metavar.t
   sharing type Ast.spine = Abt.O.Ar.Vl.Sp.t
+  sharing type Ast.P.t = Abt.P.t
 end
 
 signature AST_TO_ABT =

--- a/src/core/ast.sig
+++ b/src/core/ast.sig
@@ -27,7 +27,7 @@ sig
   sharing type Ast.operator = Abt.O.t
   sharing type Ast.metavariable = Abt.Metavar.t
   sharing type Ast.spine = Abt.O.Ar.Vl.Sp.t
-  sharing type Ast.P.t = Abt.P.t
+  sharing type Ast.P.t = Abt.O.P.t
 end
 
 signature AST_TO_ABT =

--- a/src/core/operator.fun
+++ b/src/core/operator.fun
@@ -10,6 +10,16 @@ struct
   fun map f x = x
 end
 
+functor AbtSimpleCubicalOperator (O : ABT_SIMPLE_OPERATOR) : ABT_OPERATOR =
+struct
+  local
+    structure O' = AbtSimpleOperator (O)
+  in
+    open O'
+    structure P = AbtCubicalParam
+  end
+end
+
 functor AbtEmptyOperator (Ar : ABT_ARITY) : ABT_OPERATOR =
 struct
   structure Ar = Ar and P = AbtIdParam

--- a/src/core/operator.fun
+++ b/src/core/operator.fun
@@ -1,6 +1,6 @@
 functor AbtSimpleOperator (O : ABT_SIMPLE_OPERATOR) : ABT_OPERATOR =
 struct
-  structure Ar = O.Ar
+  structure Ar = O.Ar and P = AbtIdParam
 
   type 'i t = O.t
   val arity = O.arity
@@ -12,9 +12,10 @@ end
 
 functor AbtEmptyOperator (Ar : ABT_ARITY) : ABT_OPERATOR =
 struct
-  structure Ar = Ar
+  structure Ar = Ar and P = AbtIdParam
 
   datatype 'i t = WELP of 'i t
+  type 'i param = 'i
 
   fun arity (WELP x) = arity x
   fun support (WELP x) = support x

--- a/src/core/operator.sig
+++ b/src/core/operator.sig
@@ -1,11 +1,12 @@
 signature ABT_OPERATOR =
 sig
   structure Ar : ABT_ARITY
+  structure P : ABT_PARAM
 
   type 'i t
 
   val arity : 'i t -> Ar.t
-  val support : 'i t -> ('i * Ar.Vl.sort) list
+  val support : 'i P.t t -> ('i * Ar.Vl.sort) list
 
   val eq : ('i * 'i -> bool) -> 'i t * 'i t -> bool
   val toString : ('i -> string) -> 'i t -> string

--- a/src/core/param.sig
+++ b/src/core/param.sig
@@ -1,0 +1,8 @@
+signature ABT_PARAM =
+sig
+  include MONAD
+
+  val extract : 'i t -> 'i option
+  val eq : ('i * 'i -> bool) -> 'i t * 'i t -> bool
+  val toString : ('i -> string) -> 'i t -> string
+end

--- a/src/core/param.sml
+++ b/src/core/param.sml
@@ -1,0 +1,40 @@
+structure AbtIdParam =
+struct
+  type 'i t = 'i
+  fun pure x = x
+  fun bind f x = f x
+
+  fun extract x = SOME x
+  fun eq f = f
+  fun toString f = f
+end
+
+structure AbtCubicalParam =
+struct
+  datatype 'i t =
+     NAME of 'i
+   | DIM0
+   | DIM1
+
+  val pure = NAME
+
+  fun bind f =
+    fn NAME u => f u
+     | DIM0 => DIM0
+     | DIM1 => DIM1
+
+  val extract =
+    fn NAME u => SOME u
+     | _ => NONE
+
+  fun eq f =
+    fn (NAME u, NAME v) => f (u, v)
+     | (DIM0, DIM0) => true
+     | (DIM1, DIM1) => true
+     | _ => false
+
+  fun toString f =
+    fn NAME u => f u
+     | DIM0 => "dim0"
+     | DIM1 => "dim1"
+end

--- a/src/core/show_abt.fun
+++ b/src/core/show_abt.fun
@@ -17,13 +17,13 @@ struct
          `x => ShowVar.toString x
        | theta $ es =>
            if Sp.isEmpty es then
-             O.toString (P.toString ShowSym.toString) theta
+             O.toString (O.P.toString ShowSym.toString) theta
            else
-             O.toString (P.toString ShowSym.toString) theta
+             O.toString (O.P.toString ShowSym.toString) theta
                 ^ "(" ^ Sp.pretty toStringB "; " es ^ ")"
        | mv $# (ps, ms) =>
            let
-             val ps' = Sp.pretty (P.toString ShowSym.toString o #1) "," ps
+             val ps' = Sp.pretty (O.P.toString ShowSym.toString o #1) "," ps
              val ms' = Sp.pretty toString "," ms
            in
              "#" ^ Abt.Metavar.toString mv

--- a/src/core/show_abt.fun
+++ b/src/core/show_abt.fun
@@ -17,17 +17,17 @@ struct
          `x => ShowVar.toString x
        | theta $ es =>
            if Sp.isEmpty es then
-             O.toString ShowSym.toString theta
+             O.toString (P.toString ShowSym.toString) theta
            else
-             O.toString ShowSym.toString theta
+             O.toString (P.toString ShowSym.toString) theta
                 ^ "(" ^ Sp.pretty toStringB "; " es ^ ")"
-       | mv $# (us, ms) =>
+       | mv $# (ps, ms) =>
            let
-             val us' = Sp.pretty (ShowSym.toString o #1) "," us
+             val ps' = Sp.pretty (P.toString ShowSym.toString o #1) "," ps
              val ms' = Sp.pretty toString "," ms
            in
              "#" ^ Abt.Metavar.toString mv
-                 ^ (if Sp.isEmpty us then "" else "{" ^ us' ^ "}")
+                 ^ (if Sp.isEmpty ps then "" else "{" ^ ps' ^ "}")
                  ^ (if Sp.isEmpty ms then "" else "[" ^ ms' ^ "]")
            end
 

--- a/src/core/syntax_view.fun
+++ b/src/core/syntax_view.fun
@@ -21,6 +21,7 @@ struct
   type sort = sort
   type 'a operator = 'a Ast.operator
   type 'a spine = 'a Ast.spine
+  type 'a param = 'a Ast.P.t
 
   type term = Ast.ast
 
@@ -29,14 +30,14 @@ struct
 
   datatype 'a view =
      ` of variable
-   | $ of symbol operator * 'a bview spine
-   | $# of metavariable * ((symbol * sort) spine * 'a spine)
+   | $ of symbol param operator * 'a bview spine
+   | $# of metavariable * ((symbol param * sort) spine * 'a spine)
 
   fun check (m, _) =
     case m of
        `x => Ast.` x
      | $ (th, es) => Ast.$ (th, List.map (fn \ ((us,xs), m) => Ast.\ ((us, xs), m)) es)
-     | $# (x, (us, ms)) => Ast.$# (x, (List.map #1 us, ms))
+     | $# (x, (ps, ms)) => Ast.$# (x, (List.map #1 ps, ms))
 
   fun $$ (th, es) =
     check ($ (th, es), ())

--- a/src/core/syntax_view.sig
+++ b/src/core/syntax_view.sig
@@ -6,6 +6,7 @@ sig
   type sort
   type 'a operator
   type 'a spine
+  type 'a param
 
   type term
 
@@ -14,12 +15,12 @@ sig
 
   datatype 'a view =
      ` of variable
-   | $ of symbol operator * 'a bview spine
-   | $# of metavariable * ((symbol * sort) spine * 'a spine)
+   | $ of symbol param operator * 'a bview spine
+   | $# of metavariable * ((symbol param * sort) spine * 'a spine)
 
   val check : term view * sort -> term
 
-  val $$ : symbol operator * term bview spine -> term
+  val $$ : symbol param operator * term bview spine -> term
 
   val debugToString : term -> string
   val toString : term -> string

--- a/src/json/json.fun
+++ b/src/json/json.fun
@@ -89,7 +89,7 @@ struct
              fn J.String a => a
               | m => raise DecodeAbt ("Expected String but got " ^ J.toString m)
 
-           val ((ssorts, vsorts), _) = valence
+           val ((psorts, vsorts), _) = valence
            val us = map (Abt.Sym.named o getStr) syms
            val xs = map (Abt.Var.named o getStr) vars
 
@@ -99,7 +99,7 @@ struct
            val env' = (menv, senv', venv')
 
            val (mctx, sctx, vctx) = ctx
-           val sctx' = ListPair.foldl (fn (u, sigma, r) => Abt.Sym.Ctx.insert r u sigma) sctx (us, ssorts)
+           val sctx' = ListPair.foldl (fn (u, sigma, r) => Abt.Sym.Ctx.insert r u sigma) sctx (us, psorts)
            val vctx' = ListPair.foldl (fn (x, sigma, r) => Abt.Var.Ctx.insert r x sigma) vctx (xs, vsorts)
 
            val ctx' = (mctx, sctx', vctx')

--- a/src/json/json.fun
+++ b/src/json/json.fun
@@ -30,27 +30,28 @@ struct
     fn J.String u => (NameEnv.lookup rho u handle _ => raise DecodeAbt ("Sym " ^ u ^ " not in environment"))
      | m => raise DecodeAbt ("Sym: expected String, but got " ^ J.toString m)
 
-  fun encodeSymAnn (u, sigma) =
+  fun encodeParamAnn (p, sigma) =
     J.Obj
-      [("sym", encodeSym u),
+      [("param", encodeParam encodeSym p),
        ("sort", encodeSort sigma)]
 
   fun decodeSymAnn env =
-    fn J.Obj [("sym", u), ("sort", sigma)] =>
-         (decodeSym env u,
-          Option.valOf (decodeSort u)
+    fn J.Obj [("param", p), ("sort", sigma)] =>
+         (Option.valOf (decodeParam (SOME o decodeSym env) p)
+            handle _ => raise DecodeAbt ("Failed to decode param " ^ J.toString p),
+          Option.valOf (decodeSort sigma)
             handle _ => raise DecodeAbt ("Failed to decode sort " ^ J.toString sigma))
      | m => raise DecodeAbt ("SymAnn: failed to decode " ^ J.toString m)
 
   fun encodeApp (theta, es) =
     J.Obj
-      [("op", encodeOperator encodeSym theta),
+      [("op", encodeOperator (encodeParam encodeSym) theta),
        ("args", encodeArguments es)]
 
   and decodeApp env ctx =
     fn J.Obj [("op", theta), ("args", J.Array args)] =>
         let
-          val theta = Option.valOf (decodeOperator (SOME o decodeSym env) theta) handle _ => raise DecodeAbt ("Failed to decode operator " ^ J.toString theta)
+          val theta = Option.valOf (decodeOperator (decodeParam (SOME o decodeSym env)) theta) handle _ => raise DecodeAbt ("Failed to decode operator " ^ J.toString theta)
           val (vls, _) = Abt.O.arity theta
         in
           (theta, decodeArguments env ctx vls args)
@@ -63,10 +64,10 @@ struct
   and decodeArguments env ctx vls es =
     ListPair.map (fn (e, vl) => decodeB env ctx vl e) (es, vls)
 
-  and encodeMetaApp (x, us, ms) =
+  and encodeMetaApp (x, ps, ms) =
     J.Obj
       [("metavar", encodeMetavar x),
-       ("syms", J.Array (map encodeSymAnn us)),
+       ("syms", J.Array (map encodeParamAnn ps)),
        ("args", J.Array (map encode ms))]
 
   and decodeMetaApp env ctx =
@@ -112,7 +113,7 @@ struct
     case Abt.out m of
        Abt.`x => J.Obj [("Var", encodeVar x)]
      | Abt.$ (theta, es) => J.Obj [("App", encodeApp (theta, es))]
-     | Abt.$# (x, (us, ms)) => J.Obj [("MetaApp", encodeMetaApp (x, us, ms))]
+     | Abt.$# (x, (ps, ms)) => J.Obj [("MetaApp", encodeMetaApp (x, ps, ms))]
 
   and decode (env : env) (ctx as (mctx, sctx, vctx)) =
     fn J.Obj [("Var", var)] =>

--- a/src/json/json.sig
+++ b/src/json/json.sig
@@ -23,6 +23,6 @@ sig
   val encodeOperator : ('a -> Json.json_value) -> 'a Abt.O.t -> Json.json_value
   val decodeOperator : (Json.json_value -> 'a option) -> Json.json_value -> 'a Abt.O.t option
 
-  val encodeParam : ('a -> Json.json_value) -> 'a Abt.P.t -> Json.json_value
-  val decodeParam : (Json.json_value -> 'a option) -> Json.json_value -> 'a Abt.P.t option
+  val encodeParam : ('a -> Json.json_value) -> 'a Abt.O.P.t -> Json.json_value
+  val decodeParam : (Json.json_value -> 'a option) -> Json.json_value -> 'a Abt.O.P.t option
 end

--- a/src/json/json.sig
+++ b/src/json/json.sig
@@ -22,4 +22,7 @@ sig
 
   val encodeOperator : ('a -> Json.json_value) -> 'a Abt.O.t -> Json.json_value
   val decodeOperator : (Json.json_value -> 'a option) -> Json.json_value -> 'a Abt.O.t option
+
+  val encodeParam : ('a -> Json.json_value) -> 'a Abt.P.t -> Json.json_value
+  val decodeParam : (Json.json_value -> 'a option) -> Json.json_value -> 'a Abt.P.t option
 end

--- a/src/lcs/closure.fun
+++ b/src/lcs/closure.fun
@@ -5,7 +5,7 @@ struct
 
   type 'a metaenv = 'a Abt.Metavar.Ctx.dict
   type 'a varenv = 'a Abt.Var.Ctx.dict
-  type symenv = Abt.symbol Abt.Sym.Ctx.dict
+  type symenv = Abt.symbol Abt.param Abt.Sym.Ctx.dict
 
   datatype 'a closure =
     <: of 'a * env
@@ -54,8 +54,8 @@ struct
       open Abt
       fun showMetaVarAssign (x, e) =
         Metavar.toString x ^ " ~> " ^ toStringAbs e
-      fun showSymAssign (u, v) =
-        Sym.toString u ^ " ~> " ^ Sym.toString v
+      fun showSymAssign (u, p) =
+        Sym.toString u ^ " ~> " ^ O.P.toString Sym.toString p
       fun showVarAssign (x, m) =
         Var.toString x ^ " ~> " ^ toStringAbt m
 

--- a/src/lcs/closure.sig
+++ b/src/lcs/closure.sig
@@ -4,7 +4,7 @@ sig
 
   type 'a metaenv = 'a Abt.Metavar.Ctx.dict
   type 'a varenv = 'a Abt.Var.Ctx.dict
-  type symenv = Abt.symbol Abt.Sym.Ctx.dict
+  type symenv = Abt.symbol Abt.param Abt.Sym.Ctx.dict
 
   datatype 'a closure =
     <: of 'a * (Abt.abs closure metaenv * symenv * Abt.abt closure varenv)

--- a/src/lcs/dynamics_basis.sig
+++ b/src/lcs/dynamics_basis.sig
@@ -15,9 +15,9 @@ sig
   sharing type M.Cl.Abt.O.Ar.Vl.S.t = O.S.t
   sharing type O.operator = M.Cl.Abt.O.t
 
-  type vpat = (M.Cl.Abt.symbol O.L.V.t, M.expr) M.pat
-  type kpat = (M.Cl.Abt.symbol O.L.K.t, M.expr M.Cl.closure) M.pat
-  type dpat = (M.Cl.Abt.symbol O.L.D.t, M.expr) M.pat
+  type vpat = (M.Cl.Abt.symbol M.Cl.Abt.param O.L.V.t, M.expr) M.pat
+  type kpat = (M.Cl.Abt.symbol M.Cl.Abt.param O.L.K.t, M.expr M.Cl.closure) M.pat
+  type dpat = (M.Cl.Abt.symbol M.Cl.Abt.param O.L.D.t, M.expr) M.pat
 
   val plug : Sig.t -> (M.Cl.Abt.symbol list * vpat M.Cl.closure) * kpat -> M.stack -> M.expr M.state
 

--- a/src/lcs/language.sig
+++ b/src/lcs/language.sig
@@ -11,6 +11,8 @@ sig
 
   sharing type V.Ar.Vl.S.t = K.Ar.Vl.S.t
   sharing type V.Ar.Vl.S.t = D.Ar.Vl.S.t
+  sharing type V.P.t = K.P.t
+  sharing type V.P.t = D.P.t
 
   (* The valence sort of the principal argument / input to a continuation.
      Should return a list of sorts of symbols to bind (which will in most

--- a/src/lcs/machine.fun
+++ b/src/lcs/machine.fun
@@ -11,7 +11,7 @@ struct
   type 'a cont_operator = 'a K.t
 
   type expr = Abt.abt
-  type cont = (Abt.symbol K.t, expr Cl.closure) pat
+  type cont = (Abt.symbol Abt.param K.t, expr Cl.closure) pat
   type stack = cont list
 
   datatype 'a state =
@@ -52,7 +52,7 @@ struct
         ^ Cl.toString cl
   in
     fun contToString (k `$ es) =
-      K.toString Abt.Sym.toString k
+      K.toString (Abt.O.P.toString Abt.Sym.toString) k
         ^ "("
         ^ ListSpine.pretty bindingToString ", " es
         ^ ")"

--- a/src/lcs/machine.sig
+++ b/src/lcs/machine.sig
@@ -8,7 +8,7 @@ sig
 
   type expr = Cl.Abt.abt
 
-  type cont = (Cl.Abt.symbol K.t, expr Cl.closure) pat
+  type cont = (Cl.Abt.symbol Cl.Abt.param K.t, expr Cl.closure) pat
   type stack = cont list
 
   (* Our stack machine has three phases of execution.

--- a/src/lcs/operator.fun
+++ b/src/lcs/operator.fun
@@ -4,6 +4,8 @@ struct
   open L
 
   structure S = LcsSort (structure AtomicSort = V.Ar.Vl.S val opidSort = opidSort)
+  structure P = V.P
+
   type sort = S.t
   type valence = (sort list * sort list) * sort
   type arity = valence list * sort
@@ -70,7 +72,8 @@ struct
              NONE => raise Fail "You forgot to implement opidSort"
            | SOME sigma =>
                let
-                 val supp = (opid, sigma) :: params
+                 val params' = List.foldl (fn ((p, tau), us) => case P.extract p of SOME u => (u, tau) :: us | _ => us) [] params
+                 val supp = case P.extract opid of SOME opid => (opid, sigma) :: params' | _ => params'
                in
                  List.map (fn (u, tau) => (u, S.EXP tau)) supp
                end)

--- a/src/parser/parse_abt_operator.sig
+++ b/src/parser/parse_abt_operator.sig
@@ -2,5 +2,6 @@ signature PARSE_ABT_OPERATOR =
 sig
   structure Operator : ABT_OPERATOR
 
-  val parse : string Operator.t CharParser.charParser
+  val parseParam : string Operator.P.t CharParser.charParser
+  val parse : string Operator.P.t Operator.t CharParser.charParser
 end

--- a/src/patterns/linear_unification.fun
+++ b/src/patterns/linear_unification.fun
@@ -20,7 +20,7 @@ struct
         val us = O.support ptheta
         val vs = O.support theta
       in
-        ListPair.foldlEq (fn ((u, _), (v, _), rho) => SymCtx.insert rho u v) SymCtx.empty (us, vs)
+        ListPair.foldlEq (fn ((u, _), (v, _), rho) => SymCtx.insert rho u (O.P.pure v)) SymCtx.empty (us, vs)
       end
     else
       raise UnificationFailure
@@ -31,7 +31,15 @@ struct
     else
       raise UnificationFailure
 
-  structure SymEnvUtil = ContextUtil (structure Ctx = SymCtx and Elem = Sym)
+  local
+    structure Elem =
+    struct
+      type t = symbol O.P.t
+      val eq = O.P.eq Sym.eq
+    end
+  in
+    structure SymEnvUtil = ContextUtil (structure Ctx = SymCtx and Elem = Elem)
+  end
 
   fun extendEnv rho (mv, e) =
     MetaCtx.insertMerge rho mv e (fn _ => raise UnificationFailure)

--- a/src/unparser/unparse_abt.fun
+++ b/src/unparser/unparse_abt.fun
@@ -33,17 +33,17 @@ struct
                  val es' = Sp.pretty (parens o done o goB) ";" es
                in
                  atom
-                   @@ O.toString S.toString theta
+                   @@ O.toString (O.P.toString S.toString) theta
                     ^ (if Sp.isEmpty es then "" else "(" ^ es' ^ ")")
                end
-           | x $# (us, ms) =>
+           | x $# (ps, ms) =>
                let
-                 val us' = Sp.pretty (S.toString o #1) "," us
+                 val ps' = Sp.pretty (O.P.toString S.toString o #1) "," ps
                  val ms' = Sp.pretty (parens o done o outer) "," ms
                in
                  atom
                    @@ "#" ^ M.toString x
-                    ^ (if Sp.isEmpty us then "" else "{" ^ us' ^ "}")
+                    ^ (if Sp.isEmpty ps then "" else "{" ^ ps' ^ "}")
                     ^ (if Sp.isEmpty ms then "" else "[" ^ ms' ^ "]")
                end
       and goB ((us, xs) \ m) =


### PR DESCRIPTION
The basic idea here is to situate the symbolic parameters in some user-provided monad, taking their renamings in the kleisli category of that monad.

In the case of "standard"/nominal syntax, we use the identity monad. In the case of "cubical" syntax, we use the `– + {0,1}` monad. This will allow us to have the following:
1. metavariables applied to dimension expressions
2. built-in dimension substitution (for various technical reasons, we probably cannot use this part directly in RedPRL—but it would work in principle).
