### PR TITLE
Improve error message when arities don't match

### DIFF
--- a/src/core/ast.fun
+++ b/src/core/ast.fun
@@ -95,7 +95,7 @@ struct
     handle _ =>
       Abt.Sym.named u
 
-  exception FreeMeta of string * Ast.annotation option
+  exception BadConversion of string * Ast.annotation option
 
   fun convertOpen (psi, mnames) (snames, vnames) (m, tau) =
     let
@@ -114,7 +114,8 @@ struct
            | Ast.$# (mv, (ps, ms)) =>
                let
                  val mv' = NameEnv.lookup mnames mv
-                           handle Absent => raise FreeMeta (mv, oann)
+                           handle NameEnv.Absent =>
+                                  raise BadConversion ("Free metavariable " ^ mv, oann)
                  val ((ssorts, vsorts), tau') = Abt.Metavar.Ctx.lookup psi mv'
                  val _ = if Abt.O.Ar.Vl.S.eq (tau, tau') then () else raise Fail "Convert: metavariable sort mismatch"
                  val ps' = Sp.Pair.zipEq (Sp.map (PF.map (symbol snames)) ps, ssorts)

--- a/src/core/ast.fun
+++ b/src/core/ast.fun
@@ -108,6 +108,8 @@ struct
                 val (vls, _) = Abt.O.arity theta
                 val theta' = Abt.O.map (PF.pure o symbol snames) theta
                 val es' = Sp.Pair.mapEq (convertOpenAbs (psi, mnames) (snames, vnames)) (es, vls)
+                          handle ListPair.UnequalLengths =>
+                                 raise BadConversion ("Arity mismatch for operator " ^ Abt.O.toString (fn x => x) theta, oann)
               in
                 Abt.check (Abt.$ (theta', es'), tau)
               end

--- a/src/core/ast.sig
+++ b/src/core/ast.sig
@@ -54,7 +54,7 @@ sig
 
   structure NameEnv : DICT where type key = string
 
-  exception FreeMeta of string * Ast.annotation option
+  exception BadConversion of string * Ast.annotation option
 
   (* convert a closed ast to an abt *)
   val convert


### PR DESCRIPTION
Previously, when converting an AST to an ABT, if the arity of an operator did not match how it was applied, the exception `ListPair.UnequalLengths` was raised. We all knew roughly what this meant, but this PR improves the error message.

I did this by generalizing the old `FreeMeta` exception to the new `BadConversion`, which is a general way for the conversion procedure to report an error. This way RedPRL doesn't have to handle an increasingly long list of different reasons why conversion failed.

I will open a companion PR on RedPRL that takes advantage of this.